### PR TITLE
Add support of --gen-best-candidate for compressed_truth_table_bscore

### DIFF
--- a/opencog/asmoses/combo/combo/vertex.h
+++ b/opencog/asmoses/combo/combo/vertex.h
@@ -108,7 +108,6 @@ enum __attribute__ ((packed)) builtin
 
 }
 
-
 typedef id::builtin builtin;
 
 // This idiom allows wild_card to live in namespace combo, but all

--- a/opencog/asmoses/combo/interpreter/interpreter.h
+++ b/opencog/asmoses/combo/interpreter/interpreter.h
@@ -94,8 +94,8 @@ protected:
     bool _use_boolean_inputs;
     bool _use_contin_inputs;
     const std::vector<vertex>& _mixed_inputs;
-};            
-		
+};
+
 }} // ~namespaces combo opencog
-        
+
 #endif // _OPENCOG_INTERPRETER_H

--- a/opencog/asmoses/moses/main/problem-params.cc
+++ b/opencog/asmoses/moses/main/problem-params.cc
@@ -785,9 +785,9 @@ problem_params::add_options(boost::program_options::options_description& desc)
          "Set the granularity of timestamp, in case the bscore is spread "
          "across time. Options are 'day' and 'month'.\n")
 
-        ("gen-best-tree",
-         po::value<bool>(&gen_best_tree)->default_value(false),
-         "Attempts to generate the best candidate (possibly huge and overfit) head-on. Only works combined with -Hpre for now.\n")
+        ("gen-best-candidate",
+         po::value<bool>(&gen_best_candidate)->default_value(false),
+         "Attempts to generate the best candidate (possibly huge and overfit) head-on.\n")
 
         // ======= Fitness specific params =======
         ("it-abs-err",

--- a/opencog/asmoses/moses/main/problem-params.h
+++ b/opencog/asmoses/moses/main/problem-params.h
@@ -180,10 +180,12 @@ struct problem_params : public option_base
 
     // pre params
     bool pre_positive;
-    bool gen_best_candidate;
 
     // it params
     bool it_abs_err;
+
+    // Generate canonically best candidate head-on
+    bool gen_best_candidate;
 
     // Subsample deme params
     unsigned ss_n_subsample_demes,

--- a/opencog/asmoses/moses/main/problem-params.h
+++ b/opencog/asmoses/moses/main/problem-params.h
@@ -180,7 +180,7 @@ struct problem_params : public option_base
 
     // pre params
     bool pre_positive;
-    bool gen_best_tree;
+    bool gen_best_candidate;
 
     // it params
     bool it_abs_err;

--- a/opencog/asmoses/moses/main/problem.cc
+++ b/opencog/asmoses/moses/main/problem.cc
@@ -197,7 +197,7 @@ unsigned alphabet_size(const type_tree& tt, const vertex_set ignore_ops)
     }
 
     logger().info() << "Alphabet size = " << as
-                    << " output = " << output_type;
+                    << ", output = " << output_type;
     return as;
 }
 

--- a/opencog/asmoses/moses/main/table-problems.cc
+++ b/opencog/asmoses/moses/main/table-problems.cc
@@ -347,12 +347,20 @@ void ann_table_problem::run(option_base* ob)
 	set_noise_or_ratio(bscore, as, pms.noise, pms.complexity_ratio); \
 	if (pms.meta_params.do_boosting) bscore.use_weighted_scores();   \
 	                                                                 \
+	if (pms.gen_best_candidate) {                                    \
+		/* Experimental: use canonically generated candidate */       \
+		/* as exemplar seed */                                        \
+		combo_tree tr = bscore.gen_canonical_best_candidate();        \
+		logger().info() << "Canonical program tree (non reduced) maximizing score = " << tr; \
+		pms.exemplars.push_back(tr);                                  \
+	}                                                                \
+                                                                    \
 	/* When boosting, cache must not be used, as otherwise, stale */ \
 	/* composite scores get cached and returned.*/                   \
 	if (pms.meta_params.do_boosting) pms.cache_size = 0;             \
 	behave_cscore mbcscore(bscore, pms.cache_size);                  \
 	reduct::rule* reduct_cand = pms.bool_reduct;                     \
-	reduct::rule* reduct_rep = pms.bool_reduct_rep;		             \
+	reduct::rule* reduct_rep = pms.bool_reduct_rep;             \
 	/* Use the contin reductors for everything else */               \
 	if (id::boolean_type != output_type) {                           \
 		reduct_cand = pms.contin_reduct;                             \

--- a/opencog/asmoses/moses/main/table-problems.cc
+++ b/opencog/asmoses/moses/main/table-problems.cc
@@ -394,8 +394,8 @@ void pre_table_problem::run(option_base* ob)
 	set_noise_or_ratio(bscore, as, pms.noise, pms.complexity_ratio);
 	if (pms.meta_params.do_boosting) bscore.use_weighted_scores();
 
-	if (pms.gen_best_tree) {
-		// experimental: use some canonically generated
+	if (pms.gen_best_candidate) {
+		// Experimental: use some canonically generated
 		// candidate as exemplar seed
 		combo_tree tr = bscore.gen_canonical_best_candidate();
 		logger().info() << "Canonical program tree (non reduced) maximizing precision = " << tr;

--- a/opencog/asmoses/moses/scoring/bscores.cc
+++ b/opencog/asmoses/moses/scoring/bscores.cc
@@ -481,6 +481,31 @@ behavioral_score compressed_truth_table_bscore::worst_possible_bscore() const
 	return bs;
 }
 
+combo_tree compressed_truth_table_bscore::gen_canonical_best_candidate() const
+{
+	// Generate a disjunctive normal form such
+	combo_tree tr;
+	auto head = tr.set_head(id::logical_or);
+	for (const CompressedTable::value_type &vct : _wrk_ctable) {
+		const CompressedTable::counter_t &cnt = vct.second;
+
+		// If the table output is predominantly true then create a
+		// corresponding conjunction
+		if (cnt.get(id::logical_false) < cnt.get(id::logical_true)) {
+			// Build and insert the corresponding conjunction
+			const builtin_seq& truth_row = vct.first.get_seq<builtin>();
+			combo_tree cnj = conjunction_from_truth_row(truth_row);
+			tr.replace(tr.append_child(head), cnj.begin());
+		}
+	}
+
+	// Return false if there are no conjunction
+	if (head.is_childless())
+		tr.set_head(id::logical_false);
+
+	return tr;
+}
+
 score_t compressed_truth_table_bscore::min_improv() const
 {
 	// A return value of 0.5 would be correct only if all rows had

--- a/opencog/asmoses/moses/scoring/bscores.h
+++ b/opencog/asmoses/moses/scoring/bscores.h
@@ -395,6 +395,10 @@ struct compressed_truth_table_bscore : public bscore_ctable_base
 
 	behavioral_score worst_possible_bscore() const;
 
+	// Generate the candidate that best fit the table regardless of its
+	// complexity, here, a disjunctive normal form.
+	combo_tree gen_canonical_best_candidate() const;
+
 	score_t min_improv() const;
 
 protected:

--- a/opencog/asmoses/moses/scoring/precision_bscore.cc
+++ b/opencog/asmoses/moses/scoring/precision_bscore.cc
@@ -180,7 +180,7 @@ precision_bscore::precision_bscore(const CompressedTable &ctable_,
 
 /// For boolean tables, sum the total number of 'T' values
 /// in the output.  This sum represents the best possible score
-/// i.e. we found all of the true values correcty.  The 'F's are 
+/// i.e. we found all of the true values correcty.  The 'F's are
 /// false positives.
 score_t precision_bscore::sum_outputs(const CompressedTable::counter_t &c) const
 {

--- a/opencog/asmoses/moses/scoring/precision_bscore.cc
+++ b/opencog/asmoses/moses/scoring/precision_bscore.cc
@@ -724,13 +724,10 @@ combo_tree precision_bscore::gen_canonical_best_candidate() const
 	for (const auto &v : boost::adaptors::reverse(ptc)) {
 		active += v.second.second;
 
-		// build the disjunctive clause
-		auto dch = tr.append_child(head, id::logical_and);
-		arity_t idx = 1;
-		for (const auto &input : v.second.first->first.get_seq<builtin>()) {
-			argument arg(input == id::logical_true ? idx++ : -idx++);
-			tr.append_child(dch, arg);
-		}
+		// Build and insert the corresponding conjunction
+		const builtin_seq& truth_row = v.second.first->first.get_seq<builtin>();
+		combo_tree cnj = conjunction_from_truth_row(truth_row);
+		tr.replace(tr.append_child(head), cnj.begin());
 
 		// termination conditional
 		if (_ctable_weight * min_activation <= active)

--- a/opencog/asmoses/moses/scoring/precision_bscore.cc
+++ b/opencog/asmoses/moses/scoring/precision_bscore.cc
@@ -708,14 +708,15 @@ combo_tree precision_bscore::gen_canonical_best_candidate() const
 		ptc.insert(std::make_pair(precision, std::make_pair(it, total)));
 	}
 
-	// Generate conjunctive clauses till minimum activation is
-	// reached. Note that the best precision (sao / active) can never
-	// increase for each new mpv.  Despite this, we keep going until
-	// at least min_activation is reached. It's not clear this
-	// actually gives the best candidate one can get if min_activation
-	// isn't reached, but we don't want to go below min activation
-	// anyway, so it's an acceptable inacurracy.  (It would be a
-	// problem only if activation constraint is very loose.)
+	// Generate a disjunctive normal form, composed of conjunctions
+	// till minimum activation is reached. Note that the best precision
+	// (sao / active) can never increase for each new mpv.  Despite
+	// this, we keep going until at least min_activation is
+	// reached. It's not clear this actually gives the best candidate
+	// one can get if min_activation isn't reached, but we don't want
+	// to go below min activation anyway, so it's an acceptable
+	// inacurracy.  (It would be a problem only if activation
+	// constraint is very loose.)
 	//
 	count_t active = 0.0;
 	combo_tree tr;

--- a/opencog/asmoses/moses/scoring/precision_bscore.h
+++ b/opencog/asmoses/moses/scoring/precision_bscore.h
@@ -181,7 +181,6 @@ protected:
 	double wnorm;
 	bool exact_experts;
 
-
 	bool time_bscore;           // whether the bscore is spread over
 	// the temporal axis
 	type_node output_type;

--- a/opencog/asmoses/moses/scoring/scoring_base.cc
+++ b/opencog/asmoses/moses/scoring/scoring_base.cc
@@ -97,6 +97,14 @@ bscore_base::worst_possible_bscore() const
 	return behavioral_score();
 }
 
+combo_tree
+bscore_base::gen_canonical_best_candidate() const
+{
+	OC_ASSERT(false, "--gen-best-candidate is not implemented for bscorer %s",
+	          typeid(*this).name());
+	return combo_tree();
+}
+
 /**
  * Compute the average (weighted) complexity of all the trees in the
  * ensemble.  XXX this is probably wrong, we should probably do something

--- a/opencog/asmoses/moses/scoring/scoring_base.h
+++ b/opencog/asmoses/moses/scoring/scoring_base.h
@@ -362,7 +362,30 @@ protected:
 	void recompute_weight() const;   // recompute _ctable_weight
 };
 
-// helper to log a combo_tree and its behavioral score
+/**
+ * Generate a conjunction representing a row of truth values
+ *
+ * For instance
+ *
+ * conjunction_from_truth_row({T, F, T})
+ *
+ * returns
+ *
+ * and($1 !$2 $3)
+ */
+static inline combo_tree conjunction_from_truth_row(const combo::builtin_seq& row)
+{
+	combo_tree tr;
+	auto head = tr.set_head(combo::id::logical_and);
+	arity_t idx = 1;
+	for (const combo::builtin cell : row) {
+		combo::argument arg(cell == combo::id::logical_true ? idx++ : -idx++);
+		tr.append_child(head, arg);
+	}
+	return tr;
+}
+
+// Helper to log a combo_tree and its behavioral score
 static inline void log_candidate_bscore(const combo_tree &tr,
                                         const behavioral_score &bs)
 {

--- a/opencog/asmoses/moses/scoring/scoring_base.h
+++ b/opencog/asmoses/moses/scoring/scoring_base.h
@@ -87,8 +87,12 @@ struct bscore_base
 
 	/// Return the worst possible bscore achievable with this fitness
 	/// function. This is needed during boosting, to ascertain if at
-	// least half the answers are correct.
+	/// least half the answers are correct.
 	virtual behavioral_score worst_possible_bscore() const;
+
+	/// Generate, if possible, cannonically best candidate to maximize
+	/// the score.
+	virtual combo_tree gen_canonical_best_candidate() const;
 
 	/// Return the smallest change in the score which can be considered
 	/// to be an improvement over the previous score. This is useful for

--- a/tests/moses/main/MOSESUTest.cxxtest
+++ b/tests/moses/main/MOSESUTest.cxxtest
@@ -132,12 +132,12 @@ public:
         // examples of perfect score solutions are:
         // or(and(or(!$3 $4) $1) and($2 !$3) !$4 $5)
         // or(and(or(and($4 $5) $2 $3) $1) and(or($1 $2) !$3) !$4 $5)
-        // or(and(or(!$2 $4) $1) and($2 !$3) !$4 $5) 
+        // or(and(or(!$2 $4) $1) and($2 !$3) !$4 $5)
         // or(and(or($1 $2) !$3) and(or(!$2 $4 !$5) $1) !$4 $5)
         // ... and many many more.  Need the -E3 flag to shrink it down.
         moses_test_combo({"-Hcp", cp_opt + tr_str, "-E3"}, {tr_str});
     }
-    
+
     void test_cp_contin() {
         cout << BOOST_CURRENT_FUNCTION << endl;
 

--- a/tests/moses/main/MOSESUTest.cxxtest
+++ b/tests/moses/main/MOSESUTest.cxxtest
@@ -204,4 +204,14 @@ public:
         cheap_moses_test_combo({data_file_path, max_evals, output_labels},
                                {tr_str});
     }
+
+    void test_gen_best_candidate() {
+        cout << BOOST_CURRENT_FUNCTION << endl;
+        string tr_str("and($1 $2)"),
+            data_file_path("-i" + MOSESUTest_dir + "dataset.csv"),
+            max_evals("-m0"),
+            gen_best_cand("--gen-best-candidate=1");
+        cheap_moses_test_combo({data_file_path, max_evals, gen_best_cand},
+                               {tr_str});
+    }
 };


### PR DESCRIPTION
The idea of `--gen-best-candidate` is to generate head-on a candidate that perfectly fits the data, with the obvious risk of completely overfitting it.  This is useful however for experimenting and testing moses when something might be going wrong, such as moses performing poorly in-sample, etc.  Additionally it might speed up learning in special circumstances, such as when the sample set is extremely large relative to the feature set, etc.