### PR TITLE
Add knob-probing user parameter + cleaning

### DIFF
--- a/opencog/asmoses/combo/converter/combo_atomese.cc
+++ b/opencog/asmoses/combo/converter/combo_atomese.cc
@@ -41,19 +41,17 @@ using namespace std;
 using namespace boost;
 
 ComboToAtomese::ComboToAtomese()
+	: _as(nullptr)
 {
-	_as = nullptr;
 }
 
 ComboToAtomese::ComboToAtomese(AtomSpacePtr as)
-		:_as(as)
+	: _as(as)
 {}
 
 ComboToAtomese::ComboToAtomese(type_node output_type)
-		:_output_type(output_type)
+	: _as(nullptr), _output_type(output_type)
 {
-	_as = nullptr;
-
 }
 
 Handle ComboToAtomese::operator()(const combo_tree &ct,
@@ -68,7 +66,7 @@ Handle ComboToAtomese::operator()(const combo_tree &ct,
 
 vertex_2_atom::vertex_2_atom(id::procedure_type *parent, AtomSpacePtr as,
                              const string_seq &labels, type_node output_type)
-		: _as(as), _parent(parent), _labels(labels), _out_type(output_type)
+	: _as(as), _labels(labels), _parent(parent), _out_type(output_type)
 {}
 
 std::pair<Type, Handle> vertex_2_atom::operator()(const argument &a) const

--- a/opencog/asmoses/data/table/table.h
+++ b/opencog/asmoses/data/table/table.h
@@ -598,9 +598,9 @@ struct TTable : public std::vector<boost::gregorian::date>
 public:
 	typedef boost::gregorian::date value_type;
 
-	TTable(const std::string &tl = default_timestamp_label);
+	TTable(const std::string &tl=default_timestamp_label);
 
-	TTable(const super &tt, const std::string &tl = default_timestamp_label);
+	TTable(const super &tt, const std::string &tl=default_timestamp_label);
 
 	void set_label(const std::string &);
 
@@ -618,8 +618,7 @@ struct TimedValue :
 		public boost::less_than_comparable<TimedValue>,
 		public boost::equality_comparable<TimedValue>
 {
-	TimedValue(const vertex v,
-	           const TTable::value_type t = TTable::value_type())
+	TimedValue(const vertex v, const TTable::value_type t=TTable::value_type())
 			: value(v), timestamp(t)
 	{}
 
@@ -709,9 +708,9 @@ public:
 
 	// Definition is delayed until after Table, as it uses Table.
 	template<typename Func>
-	CompressedTable(const Func &func, arity_t arity, int nsamples = -1);
+	CompressedTable(const Func &func, arity_t arity, int nsamples=-1);
 
-	CompressedTable(const std::string &_olabel = "output");
+	CompressedTable(const std::string &_olabel="output");
 
 	CompressedTable(const string_seq &labs, const type_tree &tt);
 
@@ -902,9 +901,9 @@ public:
 
 	ITable();
 
-	ITable(const type_seq &ts, const string_seq &il = string_seq());
+	ITable(const type_seq &ts, const string_seq &il=string_seq());
 
-	ITable(const super &mat, const string_seq &il = string_seq());
+	ITable(const super &mat, const string_seq &il=string_seq());
 
 	ITable(const OTable &);
 	/**
@@ -919,8 +918,8 @@ public:
 	 * It only works for contin-boolean signatures
 	 */
 	// min_contin and max_contin are used in case tt has contin inputs
-	ITable(const type_tree &tt, int nsamples = -1,
-	       contin_t min_contin = -1.0, contin_t max_contin = 1.0);
+	ITable(const type_tree &tt, int nsamples=-1,
+	       contin_t min_contin=-1.0, contin_t max_contin=1.0);
 
 	arity_t get_arity() const
 	{
@@ -953,9 +952,7 @@ public:
 	 * rows into vertex_seq (this is also a hack till it handles
 	 * multi_type_seq).
 	 */
-	void insert_col(const std::string &clab,
-	                const vertex_seq &col,
-	                int off = -1);
+	void insert_col(const std::string &clab, const vertex_seq &col, int off=-1);
 
 	/**
 	 * Delete the named feature from the input table.
@@ -1036,23 +1033,23 @@ class OTable : public vertex_seq
 public:
 	typedef vertex value_type;
 
-	OTable(const std::string &ol = default_output_label);
+	OTable(const std::string &ol=default_output_label);
 
-	OTable(const super &ot, const std::string &ol = default_output_label);
+	OTable(const super &ot, const std::string &ol=default_output_label);
 
 	/// Construct the OTable by evaluating the combo tree @tr for each
 	/// row in the input ITable.
 	OTable(const combo_tree &tr, const ITable &itable,
-	       const std::string &ol = default_output_label);
+	       const std::string &ol=default_output_label);
 
 	/// Construct the OTable by evaluating the combo tree @tr for each
 	/// row in the input CompressedTable.
 	OTable(const combo_tree &tr, const CompressedTable &ctable,
-	       const std::string &ol = default_output_label);
+	       const std::string &ol=default_output_label);
 
 	template<typename Func>
 	OTable(const Func &f, const ITable &it,
-	       const std::string &ol = default_output_label)
+	       const std::string &ol=default_output_label)
 			: label(ol)
 	{
 		for (const multi_type_seq &vs : it)
@@ -1100,14 +1097,14 @@ struct Table : public boost::equality_comparable<Table>
 	Table(const OTable &otable_, const ITable &itable_);
 
 	template<typename Func>
-	Table(const Func &func, arity_t a, int nsamples = -1) :
+	Table(const Func &func, arity_t a, int nsamples=-1) :
 			itable(gen_signature(type_node_of<bool>(),
 			                     type_node_of<bool>(), a)),
 			otable(func, itable), target_pos(0), timestamp_pos(0)
 	{}
 
-	Table(const combo_tree &tr, int nsamples = -1,
-	      contin_t min_contin = -1.0, contin_t max_contin = 1.0);
+	Table(const combo_tree &tr, int nsamples=-1,
+	      contin_t min_contin=-1.0, contin_t max_contin=1.0);
 
 	size_t size() const
 	{ return itable.size(); }

--- a/opencog/asmoses/moses/TODO.org
+++ b/opencog/asmoses/moses/TODO.org
@@ -20,8 +20,6 @@
   check that it's really correct
 - [ ] support contin reduct effort. That is, split up contin reductions
   into "easy" and "hard/time-consuming" reductions.
-- [ ] _perm_ratio is set to 0, experiment and add it to the program option
-  if that is worthwhile.
 - [ ] add number of evals remaining in distributed moses in the log
 - [ ] neighborhood_sampling method and other methods filling the deme
   should not assume the size is right and instead should use

--- a/opencog/asmoses/moses/deme/deme_expander.cc
+++ b/opencog/asmoses/moses/deme/deme_expander.cc
@@ -270,7 +270,7 @@ bool deme_expander::create_representations(const combo_tree& exemplar)
 		}
 	}
 	else {                      // no dynamic feature selection
-		ignore_ops_seq.push_back(_params.ignore_ops);
+		ignore_ops_seq.push_back(_rep_params.ignore_ops);
 		xmplr_seq.push_back(exemplar);
 	}
 

--- a/opencog/asmoses/moses/deme/deme_expander.cc
+++ b/opencog/asmoses/moses/deme/deme_expander.cc
@@ -291,7 +291,6 @@ bool deme_expander::create_representations(const combo_tree& exemplar)
 		                                   ignore_ops_seq[i],
 		                                   _params.perceptions,
 		                                   _params.actions,
-		                                   _params.linear_contin,
 		                                   _rep_params));
 
 		// If the representation is empty, try the next

--- a/opencog/asmoses/moses/deme/deme_expander.cc
+++ b/opencog/asmoses/moses/deme/deme_expander.cc
@@ -289,8 +289,6 @@ bool deme_expander::create_representations(const combo_tree& exemplar)
 		// NEXT: move to representation_parameters whatever is only used by it
 		_reps.push_back(new representation(xmplr_seq[i], _type_sig,
 		                                   ignore_ops_seq[i],
-		                                   _params.perceptions,
-		                                   _params.actions,
 		                                   _rep_params));
 
 		// If the representation is empty, try the next

--- a/opencog/asmoses/moses/deme/deme_expander.cc
+++ b/opencog/asmoses/moses/deme/deme_expander.cc
@@ -491,7 +491,7 @@ void deme_expander::optimize_demes(int max_evals, time_t max_time)
 			if (_params.atomspace_port) {
 				ComboToAtomese to_atomese(_output_type);
 				atomese_based_scorer cpx_scorer = atomese_based_scorer(_cscorer, _reps[i], _params.reduce_all, to_atomese, _labels,
-				                                                       _params.atomspace_store ? _params.as : nullptr);
+				                                                       _params.atomspace_store ? _params.atomspace : nullptr);
 				_optimize(_demes[i][j], cpx_scorer, max_evals_per_deme, max_time);
 			}
 			else {

--- a/opencog/asmoses/moses/deme/deme_expander.cc
+++ b/opencog/asmoses/moses/deme/deme_expander.cc
@@ -286,10 +286,9 @@ bool deme_expander::create_representations(const combo_tree& exemplar)
 
 		// Build a representation by adding knobs to the exemplar,
 		// creating a field set, and a mapping from field set to knobs.
-		// NEXT: move to representation_parameters whatever is only used by it
-		_reps.push_back(new representation(xmplr_seq[i], _type_sig,
-		                                   ignore_ops_seq[i],
-		                                   _rep_params));
+		representation_parameters local_rep_params(_rep_params);
+		local_rep_params.ignore_ops = ignore_ops_seq[i];
+		_reps.push_back(new representation(xmplr_seq[i], _type_sig, local_rep_params));
 
 		// If the representation is empty, try the next
 		// best-scoring exemplar.

--- a/opencog/asmoses/moses/deme/deme_expander.h
+++ b/opencog/asmoses/moses/deme/deme_expander.h
@@ -39,12 +39,11 @@ namespace moses {
 struct deme_expander
 {
 	deme_expander(const type_tree& type_signature,
-	              const reduct::rule& si_ca,
-	              const reduct::rule& si_kb,
 	              behave_cscore& sc,
 	              optimizer_base& opt,
-	              const deme_parameters& pa = deme_parameters(),
-	              const subsample_deme_filter_parameters& fp = subsample_deme_filter_parameters(),
+	              const deme_parameters& pa=deme_parameters(),
+	              const representation_parameters& rp=representation_parameters(),
+	              const subsample_deme_filter_parameters& fp=subsample_deme_filter_parameters(),
 	              type_node output_t = id::boolean_type,
 	              const string_seq& labels={});
 
@@ -132,8 +131,6 @@ protected:
 	                       const feature_set& selected_features) const;
 
 	const combo::type_tree& _type_sig;          // type signature of the exemplar
-	const reduct::rule& simplify_candidate;     // rule to simplify candidates
-	const reduct::rule& simplify_knob_building; // during knob building
 
 	// Used by random_shuffle
 	std::function<ptrdiff_t(ptrdiff_t)> random_shuffle_gen;
@@ -151,6 +148,7 @@ protected:
 	std::vector<demeID_t> _demeIDs;
 
 	const deme_parameters& _params;
+	const representation_parameters& _rep_params;
 
 	const subsample_deme_filter_parameters& _filter_params;
 	type_node _output_type;

--- a/opencog/asmoses/moses/deme/deme_params.h
+++ b/opencog/asmoses/moses/deme/deme_params.h
@@ -38,13 +38,9 @@ struct deme_parameters
 {
     deme_parameters(bool _reduce_all=true,
                     const operator_set& _ignore_ops=empty_ignore_ops,
-                    const combo_tree_ns_set* _perceptions=NULL,
-                    const combo_tree_ns_set* _actions=NULL,
                     const feature_selector* _fstor=NULL) :
         reduce_all(_reduce_all),
         ignore_ops(_ignore_ops),
-        perceptions(_perceptions),
-        actions(_actions),
         fstor(_fstor),
         atomspace_store(true),
         atomspace_port(false),
@@ -60,11 +56,6 @@ struct deme_parameters
 
     // the set of operators to ignore
     operator_set ignore_ops;
-
-    // the set of perceptions of an optional interactive agent
-    const combo_tree_ns_set* perceptions;
-    // the set of actions of an optional interactive agent
-    const combo_tree_ns_set* actions;
 
     const feature_selector* fstor;
 

--- a/opencog/asmoses/moses/deme/deme_params.h
+++ b/opencog/asmoses/moses/deme/deme_params.h
@@ -29,8 +29,6 @@
 
 namespace opencog { namespace moses {
 
-static const operator_set empty_ignore_ops = operator_set();
-
 /**
  * parameters for deme management
  */
@@ -53,9 +51,6 @@ struct deme_parameters
 
     // If true then all candidates are reduced before evaluation.
     bool reduce_all;
-
-    // the set of operators to ignore
-    operator_set ignore_ops;
 
     const feature_selector* fstor;
 

--- a/opencog/asmoses/moses/deme/deme_params.h
+++ b/opencog/asmoses/moses/deme/deme_params.h
@@ -36,17 +36,16 @@ static const operator_set empty_ignore_ops = operator_set();
  */
 struct deme_parameters
 {
-    deme_parameters(bool _reduce_all = true,
-                    const operator_set& _ignore_ops = empty_ignore_ops,
-                    const combo_tree_ns_set* _perceptions = NULL,
-                    const combo_tree_ns_set* _actions = NULL,
-                    const feature_selector* _fstor = NULL) :
+    deme_parameters(bool _reduce_all=true,
+                    const operator_set& _ignore_ops=empty_ignore_ops,
+                    const combo_tree_ns_set* _perceptions=NULL,
+                    const combo_tree_ns_set* _actions=NULL,
+                    const feature_selector* _fstor=NULL) :
         reduce_all(_reduce_all),
         ignore_ops(_ignore_ops),
         perceptions(_perceptions),
         actions(_actions),
         fstor(_fstor),
-        linear_contin(true),
         atomspace_store(true),
         atomspace_port(false),
         as(nullptr)
@@ -68,23 +67,6 @@ struct deme_parameters
     const combo_tree_ns_set* actions;
 
     const feature_selector* fstor;
-
-	// NEXT: move to representation_parameters
-    // Build only linear expressions involving contin features.
-    // This can greatly decrease the number of knobs created during
-    // representation building, resulting in much smaller field sets,
-    // and instances that can be searched more quickly. However, in
-    // order to fit the data, linear expressions may not be as good,
-    // and thus may require more time overall to find...
-    bool linear_contin;
-
-	// NEXT: move to representation_parameters
-    // Defines how many pairs of literals constituting subtrees op(l1
-    // l2) are considered while creating the prototype of an
-    // exemplar. It ranges from 0 to 1, 0 means arity positive
-    // literals and arity pairs of literals, 1 means arity positive
-    // literals and arity*(arity-1) pairs of literals
-    float perm_ratio;
 
     // Flag used to store atomese programs to atomspace
     bool atomspace_store;

--- a/opencog/asmoses/moses/deme/deme_params.h
+++ b/opencog/asmoses/moses/deme/deme_params.h
@@ -69,6 +69,7 @@ struct deme_parameters
 
     const feature_selector* fstor;
 
+	// NEXT: move to representation_parameters
     // Build only linear expressions involving contin features.
     // This can greatly decrease the number of knobs created during
     // representation building, resulting in much smaller field sets,
@@ -77,6 +78,7 @@ struct deme_parameters
     // and thus may require more time overall to find...
     bool linear_contin;
 
+	// NEXT: move to representation_parameters
     // Defines how many pairs of literals constituting subtrees op(l1
     // l2) are considered while creating the prototype of an
     // exemplar. It ranges from 0 to 1, 0 means arity positive

--- a/opencog/asmoses/moses/deme/deme_params.h
+++ b/opencog/asmoses/moses/deme/deme_params.h
@@ -34,15 +34,18 @@ namespace opencog { namespace moses {
  */
 struct deme_parameters
 {
-    deme_parameters(bool _reduce_all=true,
-                    const operator_set& _ignore_ops=empty_ignore_ops,
-                    const feature_selector* _fstor=NULL) :
+    deme_parameters(int mcpd=-1,
+                    bool _reduce_all=true,
+                    const feature_selector* _fstor=nullptr,
+                    bool as_store=true,
+                    bool as_port=false,
+                    AtomSpacePtr as=nullptr) :
+        max_candidates_per_deme(mcpd),
         reduce_all(_reduce_all),
-        ignore_ops(_ignore_ops),
         fstor(_fstor),
-        atomspace_store(true),
-        atomspace_port(false),
-        as(nullptr)
+        atomspace_store(as_store),
+        atomspace_port(as_port),
+        atomspace(as)
         {}
 
     // The max number of candidates considered to be added to the
@@ -61,7 +64,7 @@ struct deme_parameters
     bool atomspace_port;
 
     // Atomspace used for storing candidate programs and input features
-    AtomSpacePtr as;
+    AtomSpacePtr atomspace;
 };
 
 } // ~namespace moses

--- a/opencog/asmoses/moses/deme/feature_selector.h
+++ b/opencog/asmoses/moses/deme/feature_selector.h
@@ -151,7 +151,7 @@ struct feature_selector_parameters
      * negative value means all interactions.
      */
     int diversity_interaction;
-    
+
      /**
      * If enabled then expensive multiple mi over feature set
      * activations is replaced by one cheap calculation of the Jaccard

--- a/opencog/asmoses/moses/main/demo-problems.cc
+++ b/opencog/asmoses/moses/main/demo-problems.cc
@@ -108,7 +108,7 @@ void bool_problem_base::run(option_base* ob)
 	// create atomspace if the code is running through port atomspace
 	if (pms.deme_params.atomspace_port) {
 		// atomspace used for storing candidate programs
-		pms.deme_params.as = createAtomSpace();
+		pms.deme_params.atomspace = createAtomSpace();
 	}
 
 	logical_bscore bscore = get_bscore(_dparms.problem_size);
@@ -262,12 +262,12 @@ void polynomial_problem::run(option_base* ob)
 	type_tree tt = gen_signature(id::contin_type, 1);
 	ITable it(tt, (pms.nsamples>0 ? pms.nsamples : pms.default_nsamples));
 
-    if (pms.deme_params.atomspace_port) {
+	if (pms.deme_params.atomspace_port) {
 		// atomspace used for storing candidate programs
-        pms.deme_params.as = createAtomSpace();
-        type_node_seq tt_seq = type_tree_to_tyn_seq(tt);
-        it.set_types(tt_seq);
-        populate(pms.deme_params.as, it);
+		pms.deme_params.atomspace = createAtomSpace();
+		type_node_seq tt_seq = type_tree_to_tyn_seq(tt);
+		it.set_types(tt_seq);
+		populate(pms.deme_params.atomspace, it);
 	}
 
 	// sr is fundamentally a kind of non-linear regression!
@@ -400,7 +400,7 @@ void combo_problem::run(option_base* ob)
 
 	if (pms.deme_params.atomspace_port) {
 		// atomspace used for storing candidate programs
-		pms.deme_params.as = createAtomSpace();
+		pms.deme_params.atomspace = createAtomSpace();
 	}
 
 	if (output_type == id::boolean_type) {
@@ -491,7 +491,7 @@ void ann_combo_problem::run(option_base* ob)
 
 	if (pms.deme_params.atomspace_port) {
 		// atomspace used for storing candidate programs
-		pms.deme_params.as = createAtomSpace();
+		pms.deme_params.atomspace = createAtomSpace();
 	}
 
 	if (pms.nsamples <= 0)

--- a/opencog/asmoses/moses/main/demo-problems.cc
+++ b/opencog/asmoses/moses/main/demo-problems.cc
@@ -119,12 +119,10 @@ void bool_problem_base::run(option_base* ob)
 	set_noise_or_ratio(bscore, as, pms.noise, pms.complexity_ratio);
 
 	behave_cscore cscore(bscore);
-	metapop_moses_results(pms.exemplars, sig,
-	                      *pms.bool_reduct, *pms.bool_reduct_rep,
-	                      cscore,
+	metapop_moses_results(pms.exemplars, sig, cscore,
 	                      pms.opt_params, pms.hc_params, pms.ps_params,
-	                      pms.deme_params, pms.filter_params, pms.meta_params,
-	                      pms.moses_params, pms.mmr_pa);
+	                      pms.rep_params, pms.deme_params, pms.filter_params,
+	                      pms.meta_params, pms.moses_params, pms.mmr_pa);
 }
 
 // ==================================================================
@@ -288,12 +286,13 @@ void polynomial_problem::run(option_base* ob)
 
 	set_noise_or_ratio(bscore, as, pms.noise, pms.complexity_ratio);
 	behave_cscore cscore(bscore);
-	metapop_moses_results(pms.exemplars, tt,
-	                      *pms.contin_reduct, *pms.contin_reduct,
-	                      cscore,
+	pms.rep_params.opt_reduct = pms.contin_reduct;
+	pms.rep_params.rep_reduct = pms.contin_reduct;
+	metapop_moses_results(pms.exemplars, tt, cscore,
 	                      pms.opt_params, pms.hc_params, pms.ps_params,
-	                      pms.deme_params, pms.filter_params, pms.meta_params,
-	                      pms.moses_params, pms.mmr_pa, id::contin_type, it.get_labels());
+	                      pms.rep_params, pms.deme_params, pms.filter_params,
+	                      pms.meta_params, pms.moses_params, pms.mmr_pa,
+	                      id::contin_type, it.get_labels());
 }
 
 // ==================================================================
@@ -408,12 +407,10 @@ void combo_problem::run(option_base* ob)
 		// @todo: Occam's razor and nsamples is not taken into account
 		logical_bscore bscore(tr, arity);
 		behave_cscore cscore(bscore);
-		metapop_moses_results(pms.exemplars, tt,
-		                      *pms.bool_reduct, *pms.bool_reduct_rep,
-		                      cscore,
+		metapop_moses_results(pms.exemplars, tt, cscore,
 		                      pms.opt_params, pms.hc_params, pms.ps_params,
-		                      pms.deme_params, pms.filter_params, pms.meta_params,
-		                      pms.moses_params, pms.mmr_pa);
+		                      pms.rep_params, pms.deme_params, pms.filter_params,
+		                      pms.meta_params, pms.moses_params, pms.mmr_pa);
 	}
 	else if (output_type == id::contin_type) {
 
@@ -451,12 +448,12 @@ void combo_problem::run(option_base* ob)
 		contin_bscore bscore(ot, it);
 		set_noise_or_ratio(bscore, as, pms.noise, pms.complexity_ratio);
 		behave_cscore cscore(bscore);
-		metapop_moses_results(pms.exemplars, tt,
-		                      *pms.contin_reduct, *pms.contin_reduct,
-		                      cscore,
+		pms.rep_params.opt_reduct = pms.contin_reduct;
+		pms.rep_params.opt_reduct = pms.contin_reduct;
+		metapop_moses_results(pms.exemplars, tt, cscore,
 		                      pms.opt_params, pms.hc_params, pms.ps_params,
-		                      pms.deme_params, pms.filter_params, pms.meta_params,
-		                      pms.moses_params, pms.mmr_pa);
+		                      pms.rep_params, pms.deme_params, pms.filter_params,
+		                      pms.meta_params, pms.moses_params, pms.mmr_pa);
 	} else {
 		logger().error() << "Error: combo_problem: type " << tt << " not supported.";
 		std::cerr << "Error: combo_problem: type " << tt << " not supported." << std::endl;
@@ -509,12 +506,12 @@ void ann_combo_problem::run(option_base* ob)
 
 	OC_ASSERT(not pms.meta_params.do_boosting, "Boosting not supported for this problem!");
 	behave_cscore cscore(bscore);
-	metapop_moses_results(pms.exemplars, tt,
-	                      *pms.contin_reduct, *pms.contin_reduct,
-	                      cscore,
+	pms.rep_params.opt_reduct = pms.contin_reduct;
+	pms.rep_params.rep_reduct = pms.contin_reduct;
+	metapop_moses_results(pms.exemplars, tt, cscore,
 	                      pms.opt_params, pms.hc_params, pms.ps_params,
-	                      pms.deme_params, pms.filter_params, pms.meta_params,
-	                      pms.moses_params, pms.mmr_pa);
+	                      pms.rep_params, pms.deme_params, pms.filter_params,
+	                      pms.meta_params, pms.moses_params, pms.mmr_pa);
 }
 
 // ==================================================================

--- a/opencog/asmoses/moses/main/demo-problems.cc
+++ b/opencog/asmoses/moses/main/demo-problems.cc
@@ -273,7 +273,7 @@ void polynomial_problem::run(option_base* ob)
 	// sr is fundamentally a kind of non-linear regression!
 	// over-ride any flag settings regarding this.
 
-	pms.deme_params.linear_contin = false;
+	pms.rep_params.linear_contin = false;
 	int as = alphabet_size(tt, pms.ignore_ops);
 
 	contin_bscore::err_function_type eft =

--- a/opencog/asmoses/moses/main/problem-params.cc
+++ b/opencog/asmoses/moses/main/problem-params.cc
@@ -1370,7 +1370,6 @@ void problem_params::parse_options(boost::program_options::variables_map& vm)
 
     // Set deme expansion paramters
     deme_params.reduce_all = reduce_all;
-    deme_params.ignore_ops = ignore_ops; // NEXT: move to representation_parameters
     if (ss_n_subsample_demes > 1 or ss_n_subsample_fitnesses > 1) {
         // If SS-MOSES is enabled then the cache is automatically
         // disabled because SS-MOSES implies to re-evaluate the same
@@ -1492,6 +1491,7 @@ void problem_params::parse_options(boost::program_options::variables_map& vm)
     lr = reduct::logical_reduction(ignore_ops);
     rep_params.opt_reduct = lr(reduct_candidate_effort).clone();
     rep_params.rep_reduct = lr(reduct_knob_building_effort).clone();
+    rep_params.ignore_ops = ignore_ops;
     rep_params.knob_probing = parse_knob_probing(knob_probing_str);
     rep_params.linear_contin = linear_regression;
 

--- a/opencog/asmoses/moses/main/problem-params.cc
+++ b/opencog/asmoses/moses/main/problem-params.cc
@@ -453,21 +453,21 @@ problem_params::add_options(boost::program_options::options_description& desc)
          po::value<int>(&num_to_promote)->default_value(1),
          "When boosting is enabled, this sets the number of candidates "
          "that, after every deme expansion cycle, should be added to "
-         "the boosted ensemble.")
+         "the boosted ensemble.\n")
 
         ("boost-exact",
          po::value<bool>(&exact_experts)->default_value(true),
          "When boosting is enabled with the -Hpre table problem, this "
          "determines whether the expert candidates admitted into the "
          "ensemble must be perfect, exact experts, or if they can make "
-         "mistakes.")
+         "mistakes.\n")
 
         ("boost-expalpha",
          po::value<double>(&expalpha)->default_value(2.0),
          "When boosting is enabled with the -Hpre table problem, and "
          "if the experts must be exact (option above), then this "
          "determines the ad-hoc weighting that magnifies unselected "
-         "items in the dataset. ")
+         "items in the dataset.\n")
 
         ("boost-bias",
          po::value<double>(&bias_scale)->default_value(1.0),
@@ -475,13 +475,26 @@ problem_params::add_options(boost::program_options::options_description& desc)
          "if the experts are not exact, then a bias is used to distinguish "
          "the correctly selected and non-selected results.  This scale "
          "factor multiplies that bias. Best values are probably a bias "
-         "of less than one.")
+         "of less than one.\n")
 
         (opt_desc_str(reduct_knob_building_effort_opt).c_str(),
          po::value<int>(&reduct_knob_building_effort)->default_value(2),
-         "Effort allocated for reduction during knob building, 0-3, "
-         "0 means minimum effort, 3 means maximum effort. The bigger "
-         "the effort the lower the dimension of the deme.\n")
+         "Effort allocated for reduction during knob probing (see "
+         "--knob-probing for more information), 0-3, 0 means minimum "
+         "effort, 3 means maximum effort. The bigger "
+         "the effort the smaller the deme.\n")
+
+        ("knob-probing",
+         po::value<string>(&knob_probing_str)->default_value("auto"),
+         "Control whether knob probing takes place during representation "
+         "building.  0 means no probing, 1 means systematic probing, and "
+         "auto means that the decision is left to asmoses.  What is knob "
+         "probing?  During representation building, knob settings that "
+         "are expected to generate simpler candidates than the exemplar "
+         "can be discarded.  Whether it is desirable depends on the "
+         "situation, therefore such an option.  Beside knob probing can "
+         "be very expensive so disabling it could be justified in case"
+         "representation building is a computational bottleneck.\n")
 
         (opt_desc_str(max_dist_opt).c_str(),
          po::value<size_t>(&max_dist)->default_value(4),

--- a/opencog/asmoses/moses/main/problem-params.cc
+++ b/opencog/asmoses/moses/main/problem-params.cc
@@ -293,7 +293,7 @@ problem_params::add_options(boost::program_options::options_description& desc)
          "automatically disables the use of div, sin, exp and log.\n")
 
         ("logical-perm-ratio",
-         po::value<double>(&perm_ratio)->default_value(0.0),
+         po::value<float>(&rep_params.perm_ratio)->default_value(0.0),
          "When decorating boolean exemplars with knobs, this option "
          "controls how many pairs of literals of the form op(L1 L2) are "
          "created.  That is, such pairs are used to decorate the exemplar "
@@ -1370,9 +1370,8 @@ void problem_params::parse_options(boost::program_options::variables_map& vm)
 
     // Set deme expansion paramters
     deme_params.reduce_all = reduce_all;
-    deme_params.ignore_ops = ignore_ops;
-    deme_params.linear_contin = linear_regression;
-    deme_params.perm_ratio = perm_ratio;
+    deme_params.ignore_ops = ignore_ops; // NEXT: move to representation_parameters
+    deme_params.linear_contin = linear_regression; // NEXT: move to representation_parameters
     if (ss_n_subsample_demes > 1 or ss_n_subsample_fitnesses > 1) {
         // If SS-MOSES is enabled then the cache is automatically
         // disabled because SS-MOSES implies to re-evaluate the same
@@ -1490,12 +1489,11 @@ void problem_params::parse_options(boost::program_options::variables_map& vm)
     moses_params.max_time = max_time;
     moses_params.max_cnd_output = result_count;
 
-    // Logical reduction rules used during search.
+    // Representation building parameters
     lr = reduct::logical_reduction(ignore_ops);
-    bool_reduct = lr(reduct_candidate_effort).clone();
-
-    // Logical reduction rules used during representation building.
-    bool_reduct_rep = lr(reduct_knob_building_effort).clone();
+    rep_params.opt_reduct = lr(reduct_candidate_effort).clone();
+    rep_params.rep_reduct = lr(reduct_knob_building_effort).clone();
+    rep_params.knob_probing = parse_knob_probing(knob_probing_str);
 
     // Continuous reduction rules used during search and representation
     // building.

--- a/opencog/asmoses/moses/main/problem-params.cc
+++ b/opencog/asmoses/moses/main/problem-params.cc
@@ -1371,7 +1371,6 @@ void problem_params::parse_options(boost::program_options::variables_map& vm)
     // Set deme expansion paramters
     deme_params.reduce_all = reduce_all;
     deme_params.ignore_ops = ignore_ops; // NEXT: move to representation_parameters
-    deme_params.linear_contin = linear_regression; // NEXT: move to representation_parameters
     if (ss_n_subsample_demes > 1 or ss_n_subsample_fitnesses > 1) {
         // If SS-MOSES is enabled then the cache is automatically
         // disabled because SS-MOSES implies to re-evaluate the same
@@ -1494,6 +1493,7 @@ void problem_params::parse_options(boost::program_options::variables_map& vm)
     rep_params.opt_reduct = lr(reduct_candidate_effort).clone();
     rep_params.rep_reduct = lr(reduct_knob_building_effort).clone();
     rep_params.knob_probing = parse_knob_probing(knob_probing_str);
+    rep_params.linear_contin = linear_regression;
 
     // Continuous reduction rules used during search and representation
     // building.

--- a/opencog/asmoses/moses/main/problem-params.h
+++ b/opencog/asmoses/moses/main/problem-params.h
@@ -97,16 +97,19 @@ struct problem_params : public option_base
     std::string output_format_str;
     std::string output_file;
 
-    // reduct options
+    // Reduct options
     int reduct_candidate_effort;
-    int reduct_knob_building_effort;
     string_seq include_only_ops_str;
     string_seq ignore_ops_str;
     vertex_set ignore_ops;
     string_seq exemplars_str;
     combo_tree_seq exemplars;
 
-    // metapop_param
+    // Representation building options
+    int reduct_knob_building_effort;
+    std::string knob_probing_str;
+
+    // Metapopulation parameters
     int max_candidates_per_deme;
     int revisit;
     bool reduce_all;
@@ -117,7 +120,6 @@ struct problem_params : public option_base
     score_t complexity_ratio;
     double cap_coef;
     unsigned cache_size;
-    double perm_ratio;
     bool boosting;
     int num_to_promote;
     bool exact_experts;
@@ -215,14 +217,15 @@ struct problem_params : public option_base
     feature_selection_parameters& fs_params;
     std::string fs_enforce_features_filename;
 
+	// NEXT: move to representation_parameters
     reduct::rule* bool_reduct;
-    reduct::rule* bool_reduct_rep;
     reduct::rule* contin_reduct;
 
     optim_parameters opt_params;
     hc_parameters hc_params;
     ps_parameters ps_params;
     moses_parameters moses_params;
+    representation_parameters rep_params;
     deme_parameters deme_params;
     subsample_deme_filter_parameters filter_params;
     metapop_parameters meta_params;

--- a/opencog/asmoses/moses/main/problem-params.h
+++ b/opencog/asmoses/moses/main/problem-params.h
@@ -217,7 +217,6 @@ struct problem_params : public option_base
     feature_selection_parameters& fs_params;
     std::string fs_enforce_features_filename;
 
-	// NEXT: move to representation_parameters
     reduct::rule* bool_reduct;
     reduct::rule* contin_reduct;
 

--- a/opencog/asmoses/moses/main/problem-params.h
+++ b/opencog/asmoses/moses/main/problem-params.h
@@ -59,7 +59,7 @@ struct problem_params : public option_base
     void add_options(boost::program_options::options_description&);
     void parse_options(boost::program_options::variables_map&);
 
-    // program options, see options_description below for their meaning
+    // Program options, see options_description below for their meaning
     string_seq jobs_str;
     unsigned min_pool;
     bool enable_mpi;
@@ -67,7 +67,7 @@ struct problem_params : public option_base
     unsigned long rand_seed;
     std::string problem;
 
-    // default number of samples to describe a problem
+    // Default number of samples to describe a problem
     const unsigned int default_nsamples;
     int nsamples;
     double min_rand_input;
@@ -85,7 +85,7 @@ struct problem_params : public option_base
     std::string log_level;
     std::string log_file;
 
-    // output printing options (metapop_printer)
+    // Output printing options (metapop_printer)
     long result_count;
     bool output_score;
     bool output_cscore;
@@ -124,7 +124,7 @@ struct problem_params : public option_base
     double expalpha;
     double bias_scale;
 
-    // metapopulation diversity parameters
+    // Metapopulation diversity parameters
     score_t diversity_pressure;
     bool diversity_autoscale;
     score_t diversity_exponent;
@@ -139,7 +139,7 @@ struct problem_params : public option_base
     score_t max_score;
     size_t max_dist;
 
-    // contin optimization
+    // Contin optimization
     bool weighted_accuracy;
     contin_seq discretize_thresholds;
 
@@ -174,7 +174,7 @@ struct problem_params : public option_base
     // classifier parameters
     bool use_well_enough;
 
-    // hardness of the activation range -- scoring-related
+    // Hardness of the activation range -- scoring-related
     // constraint for problems pre, recall, prerec
     score_t hardness;
 

--- a/opencog/asmoses/moses/main/table-problems.cc
+++ b/opencog/asmoses/moses/main/table-problems.cc
@@ -166,9 +166,9 @@ void table_problem_base::common_setup(problem_params& pms)
 	// and populate it with the input data
 	if (pms.deme_params.atomspace_port) {
 		// atomspace used for populating features
-		pms.deme_params.as = createAtomSpace();
-		populate(pms.deme_params.as, table.itable);
-		populate(pms.deme_params.as, ctable);
+		pms.deme_params.atomspace = createAtomSpace();
+		populate(pms.deme_params.atomspace, table.itable);
+		populate(pms.deme_params.atomspace, ctable);
 	}
 
 	pms.mmr_pa.ilabels = ilabels;

--- a/opencog/asmoses/moses/main/table-problems.cc
+++ b/opencog/asmoses/moses/main/table-problems.cc
@@ -178,7 +178,7 @@ void table_problem_base::common_setup(problem_params& pms)
  * Set up the output
  */
 void table_problem_base::common_type_setup(problem_params& pms,
-										   type_node out_type)
+                                           type_node out_type)
 {
 	// Infer the signature based on the input table.
 	table_type_signature = table.get_signature();
@@ -257,13 +257,13 @@ void ip_problem::run(option_base* ob)
 	int as = alphabet_size(tt, pms.ignore_ops);
 
 	interesting_predicate_bscore bscore(ctable,
-				  _ippp.ip_kld_weight,
-				  _ippp.ip_skewness_weight,
-				  _ippp.ip_stdU_weight,
-				  _ippp.ip_skew_U_weight,
-				  pms.min_rand_input,
-				  pms.max_rand_input,
-				  pms.hardness, pms.pre_positive);
+	                                    _ippp.ip_kld_weight,
+	                                    _ippp.ip_skewness_weight,
+	                                    _ippp.ip_stdU_weight,
+	                                    _ippp.ip_skew_U_weight,
+	                                    pms.min_rand_input,
+	                                    pms.max_rand_input,
+	                                    pms.hardness, pms.pre_positive);
 	set_noise_or_ratio(bscore, as, pms.noise, pms.complexity_ratio);
 
 	// In order to support boosting, the interesting_predicate_bscore
@@ -319,7 +319,7 @@ void ann_table_problem::run(option_base* ob)
 
 	// Boosing for contin values needs a whole bunch of new code.
 	OC_ASSERT(not pms.meta_params.do_boosting,
-		"Boosting not supported for the ann problem!");
+	          "Boosting not supported for the ann problem!");
 	behave_cscore cscore(bscore, pms.cache_size);
 	metapop_moses_results(pms.exemplars, tt,
 						  reduct::ann_reduction(), reduct::ann_reduction(),

--- a/opencog/asmoses/moses/main/table-problems.cc
+++ b/opencog/asmoses/moses/main/table-problems.cc
@@ -271,14 +271,12 @@ void ip_problem::run(option_base* ob)
 	// smae length, and so that the same item always refered to the
 	// same row in the ctable.
 	OC_ASSERT(not pms.meta_params.do_boosting,
-		"Boosting not supported for the ip problem!");
+	          "Boosting not supported for the ip problem!");
 	behave_cscore mbcscore(bscore, pms.cache_size);
-	metapop_moses_results(pms.exemplars, tt,
-						  *pms.bool_reduct, *pms.bool_reduct_rep,
-						  mbcscore,
-						  pms.opt_params, pms.hc_params, pms.ps_params,
-						  pms.deme_params, pms.filter_params, pms.meta_params,
-						  pms.moses_params, pms.mmr_pa);
+	metapop_moses_results(pms.exemplars, tt, mbcscore,
+	                      pms.opt_params, pms.hc_params, pms.ps_params,
+	                      pms.rep_params, pms.deme_params, pms.filter_params,
+	                      pms.meta_params, pms.moses_params, pms.mmr_pa);
 
 }
 
@@ -321,12 +319,12 @@ void ann_table_problem::run(option_base* ob)
 	OC_ASSERT(not pms.meta_params.do_boosting,
 	          "Boosting not supported for the ann problem!");
 	behave_cscore cscore(bscore, pms.cache_size);
-	metapop_moses_results(pms.exemplars, tt,
-						  reduct::ann_reduction(), reduct::ann_reduction(),
-						  cscore,
-						  pms.opt_params, pms.hc_params, pms.ps_params,
-						  pms.deme_params, pms.filter_params, pms.meta_params,
-						  pms.moses_params, pms.mmr_pa);
+	pms.rep_params.opt_reduct = &reduct::ann_reduction();
+	pms.rep_params.rep_reduct = &reduct::ann_reduction();
+	metapop_moses_results(pms.exemplars, tt, cscore,
+	                      pms.opt_params, pms.hc_params, pms.ps_params,
+	                      pms.rep_params, pms.deme_params, pms.filter_params,
+	                      pms.meta_params, pms.moses_params, pms.mmr_pa);
 }
 
 // ==================================================================
@@ -359,19 +357,19 @@ void ann_table_problem::run(option_base* ob)
 	/* composite scores get cached and returned.*/                   \
 	if (pms.meta_params.do_boosting) pms.cache_size = 0;             \
 	behave_cscore mbcscore(bscore, pms.cache_size);                  \
-	reduct::rule* reduct_cand = pms.bool_reduct;                     \
-	reduct::rule* reduct_rep = pms.bool_reduct_rep;             \
 	/* Use the contin reductors for everything else */               \
 	if (id::boolean_type != output_type) {                           \
-		reduct_cand = pms.contin_reduct;                             \
-		reduct_rep = pms.contin_reduct;                              \
+		pms.rep_params.opt_reduct = pms.contin_reduct;                \
+		pms.rep_params.rep_reduct = pms.contin_reduct;                \
 	}                                                                \
-	string_seq labels = TABLE.get_input_labels();                          \
-	metapop_moses_results(pms.exemplars, cand_type_signature,        \
-					  *reduct_cand, *reduct_rep, mbcscore,           \
-					  pms.opt_params, pms.hc_params, pms.ps_params,  \
-					  pms.deme_params, pms.filter_params, pms.meta_params,          \
-					  pms.moses_params, pms.mmr_pa,output_type,labels);                  \
+	string_seq labels = TABLE.get_input_labels();                    \
+	metapop_moses_results(                                           \
+		pms.exemplars, cand_type_signature, mbcscore,                 \
+		pms.opt_params, pms.hc_params, pms.ps_params,                 \
+		pms.rep_params, pms.deme_params, pms.filter_params,           \
+		pms.meta_params, pms.moses_params, pms.mmr_pa,                \
+		output_type,labels                                            \
+	);                                                               \
 }
 
 void pre_table_problem::run(option_base* ob)
@@ -417,12 +415,10 @@ void pre_table_problem::run(option_base* ob)
 	if (pms.meta_params.do_boosting) pms.cache_size = 0;
 
 	behave_cscore mbcscore(bscore, pms.cache_size);
-	metapop_moses_results(pms.exemplars, cand_type_signature,
-						  *pms.bool_reduct, *pms.bool_reduct_rep,
-						  mbcscore,
-						  pms.opt_params, pms.hc_params, pms.ps_params,
-						  pms.deme_params, pms.filter_params, pms.meta_params,
-						  pms.moses_params, pms.mmr_pa);
+	metapop_moses_results(pms.exemplars, cand_type_signature, mbcscore,
+	                      pms.opt_params, pms.hc_params, pms.ps_params,
+	                      pms.rep_params, pms.deme_params, pms.filter_params,
+	                      pms.meta_params, pms.moses_params, pms.mmr_pa);
 }
 
 void pre_conj_table_problem::run(option_base* ob)
@@ -514,12 +510,12 @@ void it_table_problem::run(option_base* ob)
 			// The "leave well-enough alone" algorithm.
 			// Works. Kind of. Not as well as hoped.
 			// Might be good for some problem. See diary.
-			partial_solver well(ctable,
-								pms.exemplars, *pms.contin_reduct,
-								pms.opt_params, pms.hc_params,
-								pms.ps_params, pms.deme_params,
-								pms.filter_params, pms.meta_params,
-								pms.moses_params, pms.mmr_pa);
+			pms.rep_params.opt_reduct = pms.contin_reduct;
+			pms.rep_params.rep_reduct = pms.contin_reduct;
+			partial_solver well(ctable, pms.exemplars,
+			                    pms.opt_params, pms.hc_params, pms.ps_params,
+			                    pms.rep_params, pms.deme_params, pms.filter_params,
+			                    pms.meta_params, pms.moses_params, pms.mmr_pa);
 			well.solve();
 		} else {
 			// Much like the boolean-output-type above,

--- a/opencog/asmoses/moses/metapopulation/metapopulation.h
+++ b/opencog/asmoses/moses/metapopulation/metapopulation.h
@@ -130,25 +130,25 @@ public:
 	 */
 	metapopulation(const combo_tree_seq& bases,
 	               behave_cscore& sc,
-	               const metapop_parameters& pa = metapop_parameters(),
-	               const subsample_deme_filter_parameters& subp = subsample_deme_filter_parameters());
+	               const metapop_parameters& pa=metapop_parameters(),
+	               const subsample_deme_filter_parameters& subp=subsample_deme_filter_parameters());
 
 	metapopulation(const HandleSeq& bases,
 	               behave_cscore& sc,
-	               const metapop_parameters& pa = metapop_parameters(),
-	               const subsample_deme_filter_parameters& subp = subsample_deme_filter_parameters());
+	               const metapop_parameters& pa=metapop_parameters(),
+	               const subsample_deme_filter_parameters& subp=subsample_deme_filter_parameters());
 
 	// Like above but using a single base, and a single reduction rule.
 	/// @todo use C++11 redirection
 	metapopulation(const combo_tree& base,
 	               behave_cscore& sc,
-	               const metapop_parameters& pa = metapop_parameters(),
-	               const subsample_deme_filter_parameters& subp = subsample_deme_filter_parameters());
+	               const metapop_parameters& pa=metapop_parameters(),
+	               const subsample_deme_filter_parameters& subp=subsample_deme_filter_parameters());
 
 	metapopulation(const Handle& base,
 	               behave_cscore& sc,
 	               const metapop_parameters& pa = metapop_parameters(),
-	               const subsample_deme_filter_parameters& subp = subsample_deme_filter_parameters());
+	               const subsample_deme_filter_parameters& subp=subsample_deme_filter_parameters());
 
     ~metapopulation() {}
 

--- a/opencog/asmoses/moses/moses/moses_main.h
+++ b/opencog/asmoses/moses/moses/moses_main.h
@@ -105,12 +105,11 @@ private:
 template<typename Printer>
 void metapop_moses_results_b(const combo_tree_seq& bases,
                              const opencog::combo::type_tree& tt,
-                             const reduct::rule& si_ca,
-                             const reduct::rule& si_kb,
                              behave_cscore& sc,
                              const optim_parameters& opt_params,
                              const hc_parameters& hc_params,
                              const ps_parameters& ps_params,
+                             const representation_parameters& rep_params,
                              const deme_parameters& deme_params,
                              const subsample_deme_filter_parameters& filter_params,
                              const metapop_parameters& meta_params,
@@ -148,11 +147,12 @@ void metapop_moses_results_b(const combo_tree_seq& bases,
 	combo_tree_seq simple_bases;
 	for (const combo_tree& xmplr: bases) {
 		combo_tree siba(xmplr);
-		si_ca(siba);
+		(*rep_params.opt_reduct)(siba);
 		simple_bases.push_back(siba);
 	}
 
-	deme_expander dex(tt, si_ca, si_kb, sc, *optimizer, deme_params, filter_params, t_output, labels);
+	deme_expander dex(tt, sc, *optimizer, deme_params, rep_params,
+	                  filter_params, t_output, labels);
 	metapopulation metapop(simple_bases, sc, meta_params, filter_params);
 
 	run_moses(metapop, dex, moses_params, stats);
@@ -179,12 +179,11 @@ void autoscale_diversity(const behave_cscore& sc,
 template<typename Printer>
 void metapop_moses_results(const combo_tree_seq& bases,
                            const opencog::combo::type_tree& type_sig,
-                           const reduct::rule& si_ca,
-                           const reduct::rule& si_kb,
                            behave_cscore& c_scorer,
                            const optim_parameters opt_params,
                            const hc_parameters hc_params,
                            const ps_parameters ps_params,
+                           const representation_parameters& rep_params,
                            const deme_parameters& deme_params,
                            const subsample_deme_filter_parameters& filter_params,
                            const metapop_parameters& meta_params,
@@ -210,17 +209,16 @@ void metapop_moses_results(const combo_tree_seq& bases,
 		                     filter_params.low_dev_pressure,
 		                     filter_params.by_time);
 		behave_cscore ss_cscorer(ss_bscorer);
-		metapop_moses_results_b(bases, type_sig, si_ca, si_kb,
-		                        ss_cscorer,
+		metapop_moses_results_b(bases, type_sig, ss_cscorer,
 		                        twk_opt_params, hc_params, ps_params,
-		                        deme_params, filter_params, twk_meta_params,
-		                        twk_moses_params, printer);
+		                        rep_params, deme_params, filter_params,
+		                        twk_meta_params, twk_moses_params, printer);
 	} else {
-		metapop_moses_results_b(bases, type_sig, si_ca, si_kb,
-		                        c_scorer,
+		metapop_moses_results_b(bases, type_sig, c_scorer,
 		                        twk_opt_params, hc_params, ps_params,
-		                        deme_params, filter_params, twk_meta_params,
-		                        twk_moses_params, printer, t_output, labels);
+		                        rep_params, deme_params, filter_params,
+		                        twk_meta_params, twk_moses_params, printer,
+		                        t_output, labels);
 	}
 }
 

--- a/opencog/asmoses/moses/moses/partial.cc
+++ b/opencog/asmoses/moses/moses/partial.cc
@@ -33,10 +33,10 @@ typedef combo_tree::iterator pre_it;
 
 partial_solver::partial_solver(const CompressedTable &ctable,
                                const combo_tree_seq& exemplars,
-                               const rule& reduct,
                                const optim_parameters& opt_params,
                                const hc_parameters& hc_params,
                                const ps_parameters& ps_params,
+                               const representation_parameters& rep_params,
                                const deme_parameters& deme_params,
                                const subsample_deme_filter_parameters& filter_params,
                                const metapop_parameters& meta_params,
@@ -48,7 +48,6 @@ partial_solver::partial_solver(const CompressedTable &ctable,
      _table_type_signature(ctable.get_signature()),
      _exemplars(exemplars), _leader(id::cond),
      _prefix_count(0),
-     _reduct(reduct),
      _opt_params(opt_params),
      _hc_params(hc_params),
      _ps_params(ps_params),
@@ -103,12 +102,10 @@ void partial_solver::solve()
                         << " max_evals= " << _moses_params.max_evals
                         << " num exemplars=" << _exemplars.size();
 
-        metapop_moses_results(_exemplars, _table_type_signature,
-                              _reduct, _reduct, *_cscore,
+        metapop_moses_results(_exemplars, _table_type_signature, *_cscore,
                               _opt_params, _hc_params, _ps_params,
-                              _deme_params, _filter_params,
-                              _meta_params, _moses_params,
-                              *this);
+                              _rep_params, _deme_params, _filter_params,
+                              _meta_params, _moses_params, *this);
 
         // If done, then we run one last time, but only to invoke the
         // original printer.
@@ -120,11 +117,10 @@ void partial_solver::solve()
 
             logger().info() << "well-enough DONE!";
             metapop_moses_results(_exemplars, _table_type_signature,
-                                  _reduct, _reduct, *_straight_cscore,
+                                  *_straight_cscore,
                                   _opt_params, _hc_params, _ps_params,
-                                  _deme_params, _filter_params,
-                                  _meta_params, _moses_params,
-                                  _printer);
+                                  _rep_params, _deme_params, _filter_params,
+                                  _meta_params, _moses_params, _printer);
 
             break;
         }
@@ -177,7 +173,7 @@ void partial_solver::final_cleanup(const metapopulation& cands)
             cit = cand.insert_subtree(cit, lit);
             ++cit;
         }
-        _reduct(cand);
+        (*_rep_params.opt_reduct)(cand);
         _exemplars.push_back(cand);
     }
 

--- a/opencog/asmoses/moses/moses/partial.h
+++ b/opencog/asmoses/moses/moses/partial.h
@@ -43,10 +43,10 @@ class partial_solver
     public:
         partial_solver(const CompressedTable &ctable,
                        const combo_tree_seq& exemplars,
-                       const rule& reduct,
                        const optim_parameters& opt_params,
                        const hc_parameters& hc_params,
                        const ps_parameters& ps_params,
+                       const representation_parameters& rep_params,
                        const deme_parameters& deme_params,
                        const subsample_deme_filter_parameters&,
                        const metapop_parameters& meta_params,
@@ -115,10 +115,10 @@ class partial_solver
         combo_tree_seq _exemplars;
         combo_tree _leader;
         unsigned _prefix_count;
-        const rule& _reduct;
         optim_parameters _opt_params;
         hc_parameters _hc_params;
         ps_parameters _ps_params;
+        representation_parameters _rep_params;
         deme_parameters _deme_params;
         subsample_deme_filter_parameters _filter_params;
         metapop_parameters _meta_params;

--- a/opencog/asmoses/moses/optimization/particle-swarm.cc
+++ b/opencog/asmoses/moses/optimization/particle-swarm.cc
@@ -70,7 +70,7 @@ void particle_swarm::operator()(deme_t& best_parts,
         + sizeof(packed_t) * fields.packed_width();
 
     unsigned swarm_size = calc_swarm_size(fields);
-    unsigned dim_size = fields.dim_size();
+    // unsigned dim_size = fields.dim_size();
 
         //if(swarm_size < ps_params.max_parts){
         // If small enough, try all combinations
@@ -171,7 +171,7 @@ void particle_swarm::operator()(deme_t& best_parts,
         gettimeofday(&stop, NULL);
         timersub(&stop, &start, &elapsed);
         start = stop;
-        unsigned usec = 1000000 * elapsed.tv_sec + elapsed.tv_usec;
+        // unsigned usec = 1000000 * elapsed.tv_sec + elapsed.tv_usec;
 
         /* If we've blown our budget for evaluating the scorer,
          * then we are done. */
@@ -323,8 +323,7 @@ void particle_swarm::update_particles(deme_t& temp_parts, const deme_t& best_par
                             disc_parts.best_personal[best_index];
 
     // Over each instance
-    for(;temp_it != end_temp; temp_it++, bestp_it++,
-            vels_it++, disc_temp_it++, disc_best_it){
+    for(;temp_it != end_temp; temp_it++, bestp_it++, vels_it++, disc_temp_it++){
         instance& temp_inst = (*temp_it).first;
         const instance& bestp_inst = (*bestp_it).first;
         velocity::iterator vel = (*vels_it).begin();

--- a/opencog/asmoses/moses/representation/AtomeseRepresentation.cc
+++ b/opencog/asmoses/moses/representation/AtomeseRepresentation.cc
@@ -230,4 +230,5 @@ oc_to_string(const moses::AtomeseRepresentation &rep, const std::string &indent)
 	rep.ostream_rep(ss);
 	return ss.str();
 }
+
 }

--- a/opencog/asmoses/moses/representation/AtomeseRepresentation.cc
+++ b/opencog/asmoses/moses/representation/AtomeseRepresentation.cc
@@ -41,6 +41,7 @@ static contin_t stepsize = 1.0;
 static contin_t expansion = 2.0;
 static int depth = 5;
 
+// NEXT
 AtomeseRepresentation::AtomeseRepresentation(const reduct::rule &simplify_candidate,
                                              const reduct::rule &simplify_knob_building,
                                              const Handle &exemplar,

--- a/opencog/asmoses/moses/representation/AtomeseRepresentation.cc
+++ b/opencog/asmoses/moses/representation/AtomeseRepresentation.cc
@@ -127,8 +127,8 @@ Handle AtomeseRepresentation::get_candidate(const instance inst, bool reduce)
 }
 
 void AtomeseRepresentation::clean_atomese_prog(Handle &prog,
-                                                bool reduce,
-                                                bool knob_building)
+                                               bool reduce,
+                                               bool knob_building)
 {
 	reduct::clean_reduction()(prog);
 	if (reduce) {

--- a/opencog/asmoses/moses/representation/AtomeseRepresentation.cc
+++ b/opencog/asmoses/moses/representation/AtomeseRepresentation.cc
@@ -41,22 +41,17 @@ static contin_t stepsize = 1.0;
 static contin_t expansion = 2.0;
 static int depth = 5;
 
-// NEXT
-AtomeseRepresentation::AtomeseRepresentation(const reduct::rule &simplify_candidate,
-                                             const reduct::rule &simplify_knob_building,
-                                             const Handle &exemplar,
-                                             const Handle &t,
+AtomeseRepresentation::AtomeseRepresentation(const Handle &exemplar,
+                                             const Handle &tt,
                                              AtomSpacePtr as,
                                              const HandleSet &ignore_ops,
-                                             float perm_ratio,
-                                             bool linear_contin)
+                                             const representation_parameters& rp)
 : _exemplar(exemplar),
-  _simplify_candidate(&simplify_candidate),
-  _simplify_knob_building(&simplify_knob_building),
-  _as(as)
+  _as(as),
+  _rep_params(rp)
 {
-	BuildAtomeseKnobs(_exemplar, t, *this, _DSN, linear_contin, ignore_ops,
-	                  stepsize, expansion, depth, perm_ratio);
+	BuildAtomeseKnobs(_exemplar, tt, *this, _DSN, _rep_params.linear_contin,
+	                  ignore_ops, stepsize, expansion, depth, _rep_params.perm_ratio);
 
 	std::multiset<field_set::spec> specs;
 	for (const auto& ds : disc)
@@ -133,9 +128,9 @@ void AtomeseRepresentation::clean_atomese_prog(Handle &prog,
 	reduct::clean_reduction()(prog);
 	if (reduce) {
 		if (knob_building)
-			(*_simplify_knob_building)(prog);
+			(*_rep_params.rep_reduct)(prog);
 		else
-			(*_simplify_candidate)(prog);
+			(*_rep_params.opt_reduct)(prog);
 	}
 }
 

--- a/opencog/asmoses/moses/representation/AtomeseRepresentation.h
+++ b/opencog/asmoses/moses/representation/AtomeseRepresentation.h
@@ -44,24 +44,21 @@ namespace moses
  */
 struct AtomeseRepresentation : public boost::noncopyable, boost::equality_comparable<AtomeseRepresentation>
 {
-	AtomeseRepresentation(const reduct::rule& simplify_candidate,
-	                       const reduct::rule& simplify_knob_building,
-	                       const Handle& exemplar_,
-	                       const Handle& t,
-	                       AtomSpacePtr as,
-	                       const HandleSet& ignore_ops={},
-	                       float perm_ratio=0.0,
-	                       bool linear_contin=true);
+	AtomeseRepresentation(const Handle& exemplar,
+	                      const Handle& tt,
+	                      AtomSpacePtr as,
+	                      const HandleSet &ignore_ops,
+	                      const representation_parameters& rp);
+
 protected:
 	Handle _exemplar;
 	field_set _fields;
-	const reduct::rule* _simplify_candidate; // used to simplify candidates
-	const reduct::rule* _simplify_knob_building;
 	AtomSpacePtr _as;
 	const Handle _DSN =
 			createNode(DEFINED_SCHEMA_NODE, randstr(std::string("REP") + "-"));
 	Handle _rep;
 	HandleSeq _variables;
+	representation_parameters _rep_params;
 
 	Handle get_candidate(const Handle &h);
 

--- a/opencog/asmoses/moses/representation/AtomeseRepresentation.h
+++ b/opencog/asmoses/moses/representation/AtomeseRepresentation.h
@@ -68,6 +68,7 @@ protected:
 
 	lookup disc_lookup;
 	lookup contin_lookup;
+
 public:
 	Handle get_candidate(const instance inst, bool reduce);
 	void set_rep(Handle);

--- a/opencog/asmoses/moses/representation/AtomeseRepresentation.h
+++ b/opencog/asmoses/moses/representation/AtomeseRepresentation.h
@@ -28,6 +28,7 @@
 #include <opencog/asmoses/reduct/reduct/reduct.h>
 #include <boost/operators.hpp>
 #include "field_set.h"
+#include "representation_parameters.h"
 
 namespace opencog
 {

--- a/opencog/asmoses/moses/representation/BuildAtomeseKnobs.h
+++ b/opencog/asmoses/moses/representation/BuildAtomeseKnobs.h
@@ -39,10 +39,10 @@ struct BuildAtomeseKnobs : boost::noncopyable
 	                  const Handle &DSN,
 	                  bool linear_contin,
 	                  const HandleSet& ignore_ops={},
-	                  contin_t step_size = 1.0,
-	                  contin_t expansion = 1.0,
-	                  field_set::width_t depth = 4,
-	                  float perm_ratio = 0.0);
+	                  contin_t step_size=1.0,
+	                  contin_t expansion=1.0,
+	                  field_set::width_t depth=4,
+	                  float perm_ratio=0.0);
 
 protected:
 	Handle& _exemplar;

--- a/opencog/asmoses/moses/representation/CMakeLists.txt
+++ b/opencog/asmoses/moses/representation/CMakeLists.txt
@@ -10,11 +10,12 @@ INSTALL(FILES
         knob_mapper.h
         knobs.h
         representation.h
+        representation_parameters.h
         AtomeseRepresentation.h
         BuildAtomeseKnobs.h
         KnobLink.h
 
-	DESTINATION
+        DESTINATION
 
-	"include/opencog/${PROJECT_NAME}/moses/representation"
+        "include/opencog/${PROJECT_NAME}/moses/representation"
 )

--- a/opencog/asmoses/moses/representation/build_knobs.cc
+++ b/opencog/asmoses/moses/representation/build_knobs.cc
@@ -588,7 +588,7 @@ void build_knobs::add_logical_knobs(pre_it subtree,
 
     if (logger().is_debug_enabled()) {
         logger().debug("Created %d logical knob subtrees", np);
-        logger().debug("will use %d threads for probing tree of size %d",
+        logger().debug("Will use %d threads for probing tree of size %d",
             nthr, combo_tree(subtree).size());
         if (_skip_disc_probe)
             logger().debug("Will skip expensive disc_probe()");

--- a/opencog/asmoses/moses/representation/build_knobs.cc
+++ b/opencog/asmoses/moses/representation/build_knobs.cc
@@ -53,20 +53,54 @@ build_knobs::build_knobs(combo_tree& exemplar,
                          const operator_set& ignore_ops,
                          const combo_tree_ns_set* perceptions,
                          const combo_tree_ns_set* actions,
+                         knob_probing_enum knob_probing,
                          bool linear_regression,
                          contin_t step_size,
                          contin_t expansion,
                          field_set::width_t depth,
                          float perm_ratio)
-    : _exemplar(exemplar), _rep(rep), _skip_disc_probe(true),
-      _arity(tt.begin().number_of_children() - 1), _signature(tt),
+    : _exemplar(exemplar),
+      _signature(tt),
+      _arity(tt.begin().number_of_children() - 1),
+      _rep(rep),
+      _knob_probing(knob_probing),
+      _skip_disc_probe(true),
       _linear_contin(linear_regression),
-      _step_size(step_size), _expansion(expansion), _depth(depth),
+      _step_size(step_size),
+      _expansion(expansion),
+      _depth(depth),
       _perm_ratio(perm_ratio),
-      _ignore_ops(ignore_ops), _perceptions(perceptions), _actions(actions)
+      _ignore_ops(ignore_ops),
+      _perceptions(perceptions),
+      _actions(actions)
 {
     type_tree ot = get_signature_output(_signature);
     type_node output_type = get_type_node(ot);
+
+    // Set _skip_disc_probe depending on _knob_probing setting
+    switch(_knob_probing) {
+    case(knob_probing_enum::kp_on):
+       _skip_disc_probe = false;
+       break;
+    case(knob_probing_enum::kp_off):
+       _skip_disc_probe = true;
+       break;
+    case(knob_probing_enum::kp_auto):
+       if (output_type == id::boolean_type) {
+          // The disc_probe function is wildly expensive, but appears to
+          // provide a performance advantage when the tree consists of
+          // mostly logical operators.  Thus, if the output, and at least
+          // 1/5th of the inputs are boolean, then disc_probe-ing is
+          // probably worth it, so we turn it on.  (MixedUTest provides
+          // an example where it really is worth it).
+          if (5*boolean_arity(_signature) > type_tree_arity(_signature)) {
+             _skip_disc_probe = false;
+          }
+       }
+       break;
+    default:
+       break;
+    }
 
     // If there are perceptions/actions, then output had better be
     // an action result.
@@ -89,14 +123,6 @@ build_knobs::build_knobs(combo_tree& exemplar,
         // tree of logic ops, with anything else contin-valued wrapped
         // up in a predicate (i.e. wrapped by greater_than_zero).
 
-        // The disc_probe function is wildly expensive, but appears to
-        // provide a performance advantage when the tree consists of
-        // mostly logical operators.  Thus, if the output, and at least
-        // 1/5th of the inputs are boolean, then disc_probe-ing is
-        // probably worth it, so we turn it on.  (MixedUTest provides
-        // an example where it really is worth it).
-        if (5*boolean_arity(_signature) > type_tree_arity(_signature))
-            _skip_disc_probe = false;
 
         // Make sure top node of exemplar is a logic op.
         logical_canonize(_exemplar.begin());
@@ -127,8 +153,7 @@ build_knobs::build_knobs(combo_tree& exemplar,
     {
         std::stringstream ss;
         ss << output_type;
-        OC_ASSERT(0, "Unsupported output type, got '%s'",
-                  ss.str().c_str());
+        OC_ASSERT(0, "Unsupported output type, got '%s'", ss.str().c_str());
     }
 }
 

--- a/opencog/asmoses/moses/representation/build_knobs.h
+++ b/opencog/asmoses/moses/representation/build_knobs.h
@@ -45,19 +45,20 @@ using namespace combo;
 // build knobs on a reduced combo tree
 struct build_knobs : boost::noncopyable
 {
-    // used to be stepsize = 1.0, expansion = 2, depth = 4
+    // Used to be stepsize = 1.0, expansion = 2, depth = 4
     // Optional arguments used only for Petbrain and actions
     build_knobs(combo_tree& exemplar,
                 const type_tree& tt,
                 representation& rep,
                 const operator_set& ignore_ops = operator_set(),
-                const combo_tree_ns_set* perceptions = NULL,
-                const combo_tree_ns_set* actions = NULL,
-                bool linear_regression = true,
-                contin_t step_size = 1.0,
-                contin_t expansion = 1.0,
-                field_set::width_t depth = 4,
-                float perm_ratio = 0.0);
+                const combo_tree_ns_set* perceptions=nullptr,
+                const combo_tree_ns_set* actions=nullptr,
+                knob_probing_enum knob_probing=knob_probing_enum::kp_auto,
+                bool linear_regression=true,
+                contin_t step_size=1.0,
+                contin_t expansion=1.0,
+                field_set::width_t depth=4,
+                float perm_ratio=0.0);
 
 protected:
     void build_logical(combo_tree::iterator sub,
@@ -68,16 +69,21 @@ protected:
 
 protected:
     combo_tree& _exemplar;
-    representation& _rep;
 
-    // knob probing is expensive, skip if possible.
-    bool _skip_disc_probe;
+    // Type signature of the argument literals.
+    const type_tree _signature;
 
     // Number of arguments of the combo program.
     const combo::arity_t _arity;
 
-    // Type signature of the argument literals.
-    const type_tree _signature;
+    representation& _rep;
+
+    // Knob probing mode: auto (previous behavior), on (always used),
+    // off (never used)
+    knob_probing_enum _knob_probing;
+
+    // knob probing is expensive, skip if possible.
+    bool _skip_disc_probe;
 
     // If true, then contin knob-building only generates linear
     // expressions (i.e. so that moses performs only linear

--- a/opencog/asmoses/moses/representation/representation.cc
+++ b/opencog/asmoses/moses/representation/representation.cc
@@ -105,8 +105,7 @@ combo_tree type_to_exemplar(type_node type)
 
 representation::representation(const combo_tree& xmplr,
                                const type_tree& tt,
-                               const operator_set& ignore_ops,
-	                            const representation_parameters& rp)
+                               const representation_parameters& rp)
 	: _exemplar(xmplr), _params(rp)
 {
 	// Log before and after ... knob building can take a HUGE amount
@@ -121,7 +120,7 @@ representation::representation(const combo_tree& xmplr,
 	}
 
 	// Build the knobs.
-	build_knobs(_exemplar, tt, *this, ignore_ops,
+	build_knobs(_exemplar, tt, *this, _params.ignore_ops,
 	            _params.perceptions, _params.actions, _params.linear_contin,
 	            stepsize, expansion, depth, _params.perm_ratio);
 

--- a/opencog/asmoses/moses/representation/representation.cc
+++ b/opencog/asmoses/moses/representation/representation.cc
@@ -67,40 +67,40 @@ static int depth = 5;
 
 void set_stepsize(double new_ss)
 {
-    stepsize = new_ss;
+	stepsize = new_ss;
 }
 
 void set_expansion(double new_ex)
 {
-    expansion = new_ex;
+	expansion = new_ex;
 }
 
 void set_depth(int new_depth)
 {
-    depth = new_depth;
+	depth = new_depth;
 }
 
 combo_tree type_to_exemplar(type_node type)
 {
-    switch(type) {
-    case id::boolean_type: return combo_tree(id::logical_and);
-    case id::contin_type: return combo_tree(id::plus);
-    case id::enum_type: {
-        combo_tree tr(id::cond);
-        tr.append_child(tr.begin(), enum_t::get_random_enum());
-        return tr;
-    }
-    case id::ill_formed_type:
-        OC_ASSERT(false, "Error: the data type is incorrect, "
-                  "perhaps it has not been possible to infer it from the "
-                  "input table.");
-    default: {
-        std::stringstream ss;
-        ss << "Error: type \"" << type << "\" not supported";
-        OC_ASSERT(false, ss.str());
-    }
-    }
-    return combo_tree();
+	switch(type) {
+	case id::boolean_type: return combo_tree(id::logical_and);
+	case id::contin_type: return combo_tree(id::plus);
+	case id::enum_type: {
+		combo_tree tr(id::cond);
+		tr.append_child(tr.begin(), enum_t::get_random_enum());
+		return tr;
+	}
+	case id::ill_formed_type:
+		OC_ASSERT(false, "Error: the data type is incorrect, "
+		          "perhaps it has not been possible to infer it from the "
+		          "input table.");
+	default: {
+		std::stringstream ss;
+		ss << "Error: type \"" << type << "\" not supported";
+		OC_ASSERT(false, ss.str());
+	}
+	}
+	return combo_tree();
 }
 
 representation::representation(const reduct::rule& simplify_candidate,
@@ -112,120 +112,120 @@ representation::representation(const reduct::rule& simplify_candidate,
                                const combo_tree_ns_set* actions,
                                bool linear_contin,
                                float perm_ratio)
-    : _exemplar(exemplar_),
-      _simplify_candidate(&simplify_candidate),
-      _simplify_knob_building(&simplify_knob_building)
+	: _exemplar(exemplar_),
+	  _simplify_candidate(&simplify_candidate),
+	  _simplify_knob_building(&simplify_knob_building)
 {
-    // Log before and after ... knob building can take a HUGE amount
-    // of time for some situations ... capture these in the log file.
-    logger().info() << "Start knob building, rep size="
-                    << _exemplar.size()
-                    << " complexity="
-                    << tree_complexity(_exemplar);
-    if (logger().is_debug_enabled()) {
-        logger().debug() << "Building representation from exemplar: "
-                         << _exemplar;
-    }
+	// Log before and after ... knob building can take a HUGE amount
+	// of time for some situations ... capture these in the log file.
+	logger().info() << "Start knob building, rep size="
+	                << _exemplar.size()
+	                << " complexity="
+	                << tree_complexity(_exemplar);
+	if (logger().is_debug_enabled()) {
+		logger().debug() << "Building representation from exemplar: "
+		                 << _exemplar;
+	}
 
-    // Build the knobs.
-    build_knobs(_exemplar, tt, *this, ignore_ops,
-                perceptions, actions, linear_contin,
-                stepsize, expansion, depth, perm_ratio);
+	// Build the knobs.
+	build_knobs(_exemplar, tt, *this, ignore_ops,
+	            perceptions, actions, linear_contin,
+	            stepsize, expansion, depth, perm_ratio);
 
-    logger().info() << "After knob building, rep size="
-                    << _exemplar.size()
-                    << " complexity="
-                    << tree_complexity(_exemplar);
-    if (logger().is_fine_enabled()) {
-        logger().fine() << "Rep, after knob building: " << _exemplar;
-    }
+	logger().info() << "After knob building, rep size="
+	                << _exemplar.size()
+	                << " complexity="
+	                << tree_complexity(_exemplar);
+	if (logger().is_fine_enabled()) {
+		logger().fine() << "Rep, after knob building: " << _exemplar;
+	}
 #if 0
-    // Attempt to adjust the contin spec step size to a value that is
-    // "most likely to be useful" for exploring the neighborhood of an
-    // exemplar. Basically, we try to guess what step size we were last
-    // at when we modified this contin; we do this by lopping off
-    // factors of two until we've matched the previous pecision.
-    // This way, when exploring in a deme, we explore values near the
-    // old value, with appropriate step sizes.
-    //
-    // Unfortunately, experiments seem to discredit this idea: it often
-    // slows down the search, and rarely/never seems to provide better
-    // answers.  Leaving this commented out for now.
-    contin_map new_cmap;
-    for (contin_v& v : contin)
-    {
-        field_set::contin_spec cspec = v.first;
-        contin_t remain = fabs(cspec.mean);
-        remain -= floor(remain + 0.01f);
-        contin_t new_step = remain;
-        if (remain < 0.01f) new_step = stepsize;
-        else remain -= new_step;
-        while (0.01f < remain)
-        {
-            new_step *= 0.5f;
-            if (new_step < remain + 0.01f) remain -= new_step;
-        }
-        cspec.step_size = new_step;
-        new_cmap.insert(make_pair(cspec, v.second));
-    }
-    contin = new_cmap;
+	// Attempt to adjust the contin spec step size to a value that is
+	// "most likely to be useful" for exploring the neighborhood of an
+	// exemplar. Basically, we try to guess what step size we were last
+	// at when we modified this contin; we do this by lopping off
+	// factors of two until we've matched the previous pecision.
+	// This way, when exploring in a deme, we explore values near the
+	// old value, with appropriate step sizes.
+	//
+	// Unfortunately, experiments seem to discredit this idea: it often
+	// slows down the search, and rarely/never seems to provide better
+	// answers.  Leaving this commented out for now.
+	contin_map new_cmap;
+	for (contin_v& v : contin)
+	{
+		field_set::contin_spec cspec = v.first;
+		contin_t remain = fabs(cspec.mean);
+		remain -= floor(remain + 0.01f);
+		contin_t new_step = remain;
+		if (remain < 0.01f) new_step = stepsize;
+		else remain -= new_step;
+		while (0.01f < remain)
+		{
+			new_step *= 0.5f;
+			if (new_step < remain + 0.01f) remain -= new_step;
+		}
+		cspec.step_size = new_step;
+		new_cmap.insert(make_pair(cspec, v.second));
+	}
+	contin = new_cmap;
 #endif
 
-    // Convert the knobs into a field set.
-    std::multiset<field_set::spec> tmp;
-    for (const disc_v& v : disc)
-        tmp.insert(v.first);
-    for (const contin_v& v : contin)
-        tmp.insert(v.first);
-    _fields = field_set(tmp.begin(), tmp.end());
+	// Convert the knobs into a field set.
+	std::multiset<field_set::spec> tmp;
+	for (const disc_v& v : disc)
+		tmp.insert(v.first);
+	for (const contin_v& v : contin)
+		tmp.insert(v.first);
+	_fields = field_set(tmp.begin(), tmp.end());
 
-    logger().info() << "Total number of field specs: " << tmp.size();
+	logger().info() << "Total number of field specs: " << tmp.size();
 
-    // Build a reversed-lookup table for disc and contin knobs.
-    // That is, given an iterator pointing into the exemplar, fetch the
-    // correspinding knob (if any).
-    size_t offset = 0;
-    for (disc_map_cit dit = disc.cbegin(); dit != disc.cend(); dit++) {
-        const disc_v& v = *dit;
-        pre_it pit = v.second->get_loc();
-        it_disc_knob[pit] = dit;
-        // offset used to be calculated like this:
-        // size_t offset = distance(disc.cbegin(), dit);
-        // but distance() is 3000x slower!! The trick here is that the
-        // knobs and fields are in exactly the same order, so this works.
-        it_disc_idx[pit] = _fields.begin_disc_raw_idx() + offset;
-        offset ++;
-    }
-    logger().info() << "Number of disc knobs mapped: " << disc.size();
+	// Build a reversed-lookup table for disc and contin knobs.
+	// That is, given an iterator pointing into the exemplar, fetch the
+	// correspinding knob (if any).
+	size_t offset = 0;
+	for (disc_map_cit dit = disc.cbegin(); dit != disc.cend(); dit++) {
+		const disc_v& v = *dit;
+		pre_it pit = v.second->get_loc();
+		it_disc_knob[pit] = dit;
+		// offset used to be calculated like this:
+		// size_t offset = distance(disc.cbegin(), dit);
+		// but distance() is 3000x slower!! The trick here is that the
+		// knobs and fields are in exactly the same order, so this works.
+		it_disc_idx[pit] = _fields.begin_disc_raw_idx() + offset;
+		offset ++;
+	}
+	logger().info() << "Number of disc knobs mapped: " << disc.size();
 
-    offset = 0;
-    for (contin_map_cit cit = contin.cbegin(); cit != contin.cend(); cit++) {
-        const contin_v& v = *cit;
-        pre_it pit = v.second.get_loc();
-        it_contin_knob[pit] = cit;
-        // size_t offset = distance(contin.cbegin(), cit); per comments above.
-        it_contin_idx[pit] = _fields.begin_contin_raw_idx() + offset;
-        offset++;
-    }
-    logger().info() << "Number of contin knobs mapped: " << contin.size();
-    logger().info() << "Field set, in bytes: " << _fields.byte_size();
-    size_t is = sizeof(instance) + sizeof(packed_t) * _fields.packed_width();
-    logger().info() << "One instance, in bytes: " << is;
+	offset = 0;
+	for (contin_map_cit cit = contin.cbegin(); cit != contin.cend(); cit++) {
+		const contin_v& v = *cit;
+		pre_it pit = v.second.get_loc();
+		it_contin_knob[pit] = cit;
+		// size_t offset = distance(contin.cbegin(), cit); per comments above.
+		it_contin_idx[pit] = _fields.begin_contin_raw_idx() + offset;
+		offset++;
+	}
+	logger().info() << "Number of contin knobs mapped: " << contin.size();
+	logger().info() << "Field set, in bytes: " << _fields.byte_size();
+	size_t is = sizeof(instance) + sizeof(packed_t) * _fields.packed_width();
+	logger().info() << "One instance, in bytes: " << is;
 
-    if (logger().is_debug_enabled()) {
-        std::stringstream ss;
-        ostream_prototype(ss << "Created prototype: ");
-        logger().debug(ss.str());
-    }
+	if (logger().is_debug_enabled()) {
+		std::stringstream ss;
+		ostream_prototype(ss << "Created prototype: ");
+		logger().debug(ss.str());
+	}
 
 #ifdef EXEMPLAR_INST_IS_UNDEAD
-    set_exemplar_inst();
+	set_exemplar_inst();
 
-    {
-        std::stringstream ss;
-        ss << "Exemplar instance: " << _fields.to_string(_exemplar_inst);
-        logger().debug(ss.str());
-    }
+	{
+		std::stringstream ss;
+		ss << "Exemplar instance: " << _fields.to_string(_exemplar_inst);
+		logger().debug(ss.str());
+	}
 #endif // EXEMPLAR_INST_IS_UNDEAD
 }
 
@@ -233,68 +233,68 @@ representation::representation(const reduct::rule& simplify_candidate,
 /// the instance supplied as the argument.
 void representation::transform(const instance& inst)
 {
-    // XXX TODO need to add support for "term algebra" knobs
+	// XXX TODO need to add support for "term algebra" knobs
 
-    contin_map_it ckb = contin.begin();
-    for (field_set::const_contin_iterator ci = _fields.begin_contin(inst);
-            ci != _fields.end_contin(inst); ++ci, ++ckb) {
-        ckb->second.turn(*ci);
-        //_exemplar.validate();
-    }
+	contin_map_it ckb = contin.begin();
+	for (field_set::const_contin_iterator ci = _fields.begin_contin(inst);
+	     ci != _fields.end_contin(inst); ++ci, ++ckb) {
+		ckb->second.turn(*ci);
+		//_exemplar.validate();
+	}
 
-    // cout << _fields.to_string(inst) << endl;
-    disc_map_it dkb = disc.begin();
-    for (field_set::const_disc_iterator di = _fields.begin_disc(inst);
-            di != _fields.end_disc(inst); ++di, ++dkb) {
-        dkb->second->turn(*di);
-        //_exemplar.validate();
-    }
+	// cout << _fields.to_string(inst) << endl;
+	disc_map_it dkb = disc.begin();
+	for (field_set::const_disc_iterator di = _fields.begin_disc(inst);
+	     di != _fields.end_disc(inst); ++di, ++dkb) {
+		dkb->second->turn(*di);
+		//_exemplar.validate();
+	}
 
-    for (field_set::const_bit_iterator bi = _fields.begin_bit(inst);
-            bi != _fields.end_bit(inst); ++bi, ++dkb) {
-        dkb->second->turn(*bi);
-    }
-    //cout << _exemplar << endl;
-    // std::cout << "New exemplar (after build): " << _exemplar << std::endl;
+	for (field_set::const_bit_iterator bi = _fields.begin_bit(inst);
+	     bi != _fields.end_bit(inst); ++bi, ++dkb) {
+		dkb->second->turn(*bi);
+	}
+	//cout << _exemplar << endl;
+	// std::cout << "New exemplar (after build): " << _exemplar << std::endl;
 }
 
 combo_tree representation::get_clean_exemplar(bool reduce,
                                               bool knob_building) const
 {
-    // Make a copy -- expensive! but necessary.
-    combo_tree tr = exemplar();
-    clean_combo_tree(tr, reduce, knob_building);
-    return tr;
+	// Make a copy -- expensive! but necessary.
+	combo_tree tr = exemplar();
+	clean_combo_tree(tr, reduce, knob_building);
+	return tr;
 }
 
 void representation::clean_combo_tree(combo_tree &tr,
                                       bool reduce,
                                       bool knob_building) const
 {
-    using namespace reduct;
+	using namespace reduct;
 
-    // Remove null vertices.
-    clean_reduce(tr);
+	// Remove null vertices.
+	clean_reduce(tr);
 
-    if (reduce) { //reduce
+	if (reduce) { //reduce
 #ifdef __FINE_LOG_CND_REDUCED__
-        // Save some cpu time by not even running this if-test.
-        if (logger().isFineEnabled()) {
-            logger().fine() << "Reduce "
-                            << (knob_building? "(knob_building)" : "")
-                            << " candidate: " << tr;
-        }
+		// Save some cpu time by not even running this if-test.
+		if (logger().isFineEnabled()) {
+			logger().fine() << "Reduce "
+								 << (knob_building? "(knob_building)" : "")
+								 << " candidate: " << tr;
+		}
 #endif
-        if (knob_building)
-            (*get_simplify_knob_building())(tr);
-        else
-            (*get_simplify_candidate())(tr);
-#ifdef __FINE_LOG_CND_REDUCED 
-        if (logger().isFineEnabled()) {
-            logger().fine() << "Reduced candidate: " << tr;
-        }
+		if (knob_building)
+			(*get_simplify_knob_building())(tr);
+		else
+			(*get_simplify_candidate())(tr);
+#ifdef __FINE_LOG_CND_REDUCED
+		if (logger().isFineEnabled()) {
+			logger().fine() << "Reduced candidate: " << tr;
+		}
 #endif
-    }
+	}
 }
 
 /// Create a combo tree that corresponds to the instance inst.
@@ -308,17 +308,17 @@ void representation::clean_combo_tree(combo_tree &tr,
 /// and scales better on multi-proc (as it is locker free)
 combo_tree representation::get_candidate_lock(const instance& inst, bool reduce)
 {
-    // In order to make this method thread-safe, a copy of the exemplar
-    // must be made under the lock, after the transform step.
-    // Unfortunately, copying the exemplar is expensive, but seemingly
-    // unavoidable: the knob mapper only works for the member _exemplar.
-    // Thus we cannot have "const combo_tree &tr = exemplar();"
-    boost::mutex::scoped_lock lock(tranform_mutex);
-    transform(inst);
-    combo_tree tr = exemplar();  // make copy before unlocking.
-    lock.unlock();
-    clean_combo_tree(tr, reduce);
-    return tr;
+	// In order to make this method thread-safe, a copy of the exemplar
+	// must be made under the lock, after the transform step.
+	// Unfortunately, copying the exemplar is expensive, but seemingly
+	// unavoidable: the knob mapper only works for the member _exemplar.
+	// Thus we cannot have "const combo_tree &tr = exemplar();"
+	boost::mutex::scoped_lock lock(tranform_mutex);
+	transform(inst);
+	combo_tree tr = exemplar();  // make copy before unlocking.
+	lock.unlock();
+	clean_combo_tree(tr, reduce);
+	return tr;
 }
 
 /// Create a combo tree that corresponds to the instance inst.
@@ -329,12 +329,12 @@ combo_tree representation::get_candidate_lock(const instance& inst, bool reduce)
 // modify _exemplar, instead it build the combo tree from scratch
 combo_tree representation::get_candidate(const instance& inst, bool reduce) const
 {
-    combo_tree candidate;
-    get_candidate_rec(inst, _exemplar.begin(), candidate.end(), candidate);
-    // this can probably be simplified, it doesn't need to remove
-    // null_vertices anymore
-    clean_combo_tree(candidate, reduce);
-    return candidate;
+	combo_tree candidate;
+	get_candidate_rec(inst, _exemplar.begin(), candidate.end(), candidate);
+	// this can probably be simplified, it doesn't need to remove
+	// null_vertices anymore
+	clean_combo_tree(candidate, reduce);
+	return candidate;
 }
 
 /// Copy (append) *src, with knobs turned according 'inst', to be a
@@ -347,44 +347,44 @@ void representation::get_candidate_rec(const instance& inst,
                                        combo_tree::iterator parent_dst,
                                        combo_tree& candidate) const
 {
-    typedef combo_tree::iterator pre_it;
-    typedef combo_tree::sibling_iterator sib_it;
+	typedef combo_tree::iterator pre_it;
+	typedef combo_tree::sibling_iterator sib_it;
 
-    // recursive call on the children of src to parent_dst
-    auto recursive_call = [&inst, &candidate, this](pre_it new_parent_dst,
-                                                    pre_it src)
-    {
-        for (sib_it src_child = src.begin(); src_child != src.end(); ++src_child)
-            get_candidate_rec(inst, src_child, new_parent_dst, candidate);
-    };
+	// recursive call on the children of src to parent_dst
+	auto recursive_call = [&inst, &candidate, this](pre_it new_parent_dst,
+	                                                pre_it src)
+		{
+			for (sib_it src_child = src.begin(); src_child != src.end(); ++src_child)
+				get_candidate_rec(inst, src_child, new_parent_dst, candidate);
+		};
 
-    // Find the knob associated to src (if any)
-    disc_map_cit dcit = find_disc_knob(src);
-    if (dcit != disc.end()) {
-        int d = _fields.get_raw(inst, it_disc_idx.find(src)->second);
-        pre_it new_src = dcit->second->append_to(candidate, parent_dst, d);
-        if (_exemplar.is_valid(new_src))
-            recursive_call(parent_dst, new_src);
-        return;
-    }
+	// Find the knob associated to src (if any)
+	disc_map_cit dcit = find_disc_knob(src);
+	if (dcit != disc.end()) {
+		int d = _fields.get_raw(inst, it_disc_idx.find(src)->second);
+		pre_it new_src = dcit->second->append_to(candidate, parent_dst, d);
+		if (_exemplar.is_valid(new_src))
+			recursive_call(parent_dst, new_src);
+		return;
+	}
 
-    contin_map_cit ccit = find_contin_knob(src);
-    if (ccit != contin.end()) {
-         contin_t c = _fields.get_contin(inst, it_contin_idx.find(src)->second);
-         ccit->second.append_to(candidate, parent_dst, c);
-         return;
-    }
+	contin_map_cit ccit = find_contin_knob(src);
+	if (ccit != contin.end()) {
+		contin_t c = _fields.get_contin(inst, it_contin_idx.find(src)->second);
+		ccit->second.append_to(candidate, parent_dst, c);
+		return;
+	}
 
-    // append v to parent_dst's children. If candidate is empty then
-    // set it as head. Return the iterator pointing to the new content.
-    auto append_child = [&candidate](pre_it parent_dst, const vertex& v)
-    {
-        return candidate.empty()? candidate.set_head(v)
-            : candidate.append_child(parent_dst, v);
-    };
+	// append v to parent_dst's children. If candidate is empty then
+	// set it as head. Return the iterator pointing to the new content.
+	auto append_child = [&candidate](pre_it parent_dst, const vertex& v)
+		{
+			return candidate.empty()? candidate.set_head(v)
+				: candidate.append_child(parent_dst, v);
+		};
 
-    // There was no knob.  Just copy.
-    recursive_call(append_child(parent_dst, *src), src);
+	// There was no knob.  Just copy.
+	recursive_call(append_child(parent_dst, *src), src);
 }
 
 #ifdef EXEMPLAR_INST_IS_UNDEAD
@@ -399,10 +399,10 @@ void representation::get_candidate_rec(const instance& inst,
 //  not needed either!?
 void representation::clear_exemplar()
 {
-    for (disc_v& v : disc)
-        v.second->clear_exemplar();
-    for (contin_v& v : contin)
-        v.second.clear_exemplar();
+	for (disc_v& v : disc)
+		v.second->clear_exemplar();
+	for (contin_v& v : contin)
+		v.second.clear_exemplar();
 }
 
 // What is this doing ? seems to be clearing things out, why do we need this?
@@ -411,29 +411,29 @@ void representation::clear_exemplar()
 // they match the exmplar?  Do we even need the exemplar_inst for anything?
 void representation::set_exemplar_inst()
 {
-    OC_ASSERT(_exemplar_inst.empty(),
-              "Should be called only once,"
-              " therefore _exemplar_inst should be empty");
-    _exemplar_inst.resize(_fields.packed_width());
+	OC_ASSERT(_exemplar_inst.empty(),
+	          "Should be called only once,"
+	          " therefore _exemplar_inst should be empty");
+	_exemplar_inst.resize(_fields.packed_width());
 
-    // @todo: term algebras
-    // bit
-    for(field_set::bit_iterator it = _fields.begin_bit(_exemplar_inst);
-        it != _fields.end_bit(_exemplar_inst); ++it)
-        *it = false;
-    // disc
-    for(field_set::disc_iterator it = _fields.begin_disc(_exemplar_inst);
-        it != _fields.end_disc(_exemplar_inst); ++it)
-        *it = 0;
-    // contin
-    contin_map_cit c_cit = contin.begin();
-    for(field_set::contin_iterator it = _fields.begin_contin(_exemplar_inst);
-        it != _fields.end_contin(_exemplar_inst); ++it, ++c_cit) {
-        // this should actually set the contin knob to Stop ...
-        // because the mean of the associated contin field is
-        // equal to the initial contin value
-        *it = get_contin(*c_cit->second.get_loc());
-    }
+	// @todo: term algebras
+	// bit
+	for(field_set::bit_iterator it = _fields.begin_bit(_exemplar_inst);
+		 it != _fields.end_bit(_exemplar_inst); ++it)
+		*it = false;
+	// disc
+	for(field_set::disc_iterator it = _fields.begin_disc(_exemplar_inst);
+	    it != _fields.end_disc(_exemplar_inst); ++it)
+		*it = 0;
+	// contin
+	contin_map_cit c_cit = contin.begin();
+	for(field_set::contin_iterator it = _fields.begin_contin(_exemplar_inst);
+	    it != _fields.end_contin(_exemplar_inst); ++it, ++c_cit) {
+		// this should actually set the contin knob to Stop ...
+		// because the mean of the associated contin field is
+		// equal to the initial contin value
+		*it = get_contin(*c_cit->second.get_loc());
+	}
 }
 #endif // EXEMPLAR_INST_IS_UNDEAD
 

--- a/opencog/asmoses/moses/representation/representation.cc
+++ b/opencog/asmoses/moses/representation/representation.cc
@@ -106,8 +106,6 @@ combo_tree type_to_exemplar(type_node type)
 representation::representation(const combo_tree& xmplr,
                                const type_tree& tt,
                                const operator_set& ignore_ops,
-                               const combo_tree_ns_set* perceptions, // NEXT
-                               const combo_tree_ns_set* actions, // NEXT
 	                            const representation_parameters& rp)
 	: _exemplar(xmplr), _params(rp)
 {
@@ -124,7 +122,7 @@ representation::representation(const combo_tree& xmplr,
 
 	// Build the knobs.
 	build_knobs(_exemplar, tt, *this, ignore_ops,
-	            perceptions, actions, _params.linear_contin,
+	            _params.perceptions, _params.actions, _params.linear_contin,
 	            stepsize, expansion, depth, _params.perm_ratio);
 
 	logger().info() << "After knob building, rep size="

--- a/opencog/asmoses/moses/representation/representation.cc
+++ b/opencog/asmoses/moses/representation/representation.cc
@@ -108,7 +108,6 @@ representation::representation(const combo_tree& xmplr,
                                const operator_set& ignore_ops,
                                const combo_tree_ns_set* perceptions, // NEXT
                                const combo_tree_ns_set* actions, // NEXT
-                               bool linear_contin, // NEXT
 	                            const representation_parameters& rp)
 	: _exemplar(xmplr), _params(rp)
 {
@@ -125,7 +124,7 @@ representation::representation(const combo_tree& xmplr,
 
 	// Build the knobs.
 	build_knobs(_exemplar, tt, *this, ignore_ops,
-	            perceptions, actions, linear_contin,
+	            perceptions, actions, _params.linear_contin,
 	            stepsize, expansion, depth, _params.perm_ratio);
 
 	logger().info() << "After knob building, rep size="

--- a/opencog/asmoses/moses/representation/representation.cc
+++ b/opencog/asmoses/moses/representation/representation.cc
@@ -431,4 +431,13 @@ void representation::set_exemplar_inst()
 #endif // EXEMPLAR_INST_IS_UNDEAD
 
 } // ~namespace moses
+
+std::string
+oc_to_string(const moses::representation &rep, const std::string &indent)
+{
+	std::stringstream ss;
+	rep.ostream_prototype(ss);
+	return ss.str();
+}
+
 } // ~namespace opencog

--- a/opencog/asmoses/moses/representation/representation.cc
+++ b/opencog/asmoses/moses/representation/representation.cc
@@ -103,18 +103,14 @@ combo_tree type_to_exemplar(type_node type)
 	return combo_tree();
 }
 
-representation::representation(const reduct::rule& simplify_candidate,
-                               const reduct::rule& simplify_knob_building,
-                               const combo_tree& exemplar_,
+representation::representation(const combo_tree& xmplr,
                                const type_tree& tt,
                                const operator_set& ignore_ops,
-                               const combo_tree_ns_set* perceptions,
-                               const combo_tree_ns_set* actions,
-                               bool linear_contin,
-                               float perm_ratio)
-	: _exemplar(exemplar_),
-	  _simplify_candidate(&simplify_candidate),
-	  _simplify_knob_building(&simplify_knob_building)
+                               const combo_tree_ns_set* perceptions, // NEXT
+                               const combo_tree_ns_set* actions, // NEXT
+                               bool linear_contin, // NEXT
+	                            const representation_parameters& rp)
+	: _exemplar(xmplr), _params(rp)
 {
 	// Log before and after ... knob building can take a HUGE amount
 	// of time for some situations ... capture these in the log file.
@@ -130,7 +126,7 @@ representation::representation(const reduct::rule& simplify_candidate,
 	// Build the knobs.
 	build_knobs(_exemplar, tt, *this, ignore_ops,
 	            perceptions, actions, linear_contin,
-	            stepsize, expansion, depth, perm_ratio);
+	            stepsize, expansion, depth, _params.perm_ratio);
 
 	logger().info() << "After knob building, rep size="
 	                << _exemplar.size()
@@ -285,10 +281,11 @@ void representation::clean_combo_tree(combo_tree &tr,
 								 << " candidate: " << tr;
 		}
 #endif
+		// NEXT: Where is that used during knob building?
 		if (knob_building)
-			(*get_simplify_knob_building())(tr);
+			(*rep_reduct())(tr);
 		else
-			(*get_simplify_candidate())(tr);
+			(*opt_reduct())(tr);
 #ifdef __FINE_LOG_CND_REDUCED
 		if (logger().isFineEnabled()) {
 			logger().fine() << "Reduced candidate: " << tr;

--- a/opencog/asmoses/moses/representation/representation.cc
+++ b/opencog/asmoses/moses/representation/representation.cc
@@ -121,7 +121,8 @@ representation::representation(const combo_tree& xmplr,
 
 	// Build the knobs.
 	build_knobs(_exemplar, tt, *this, _params.ignore_ops,
-	            _params.perceptions, _params.actions, _params.linear_contin,
+	            _params.perceptions, _params.actions,
+	            _params.knob_probing, _params.linear_contin,
 	            stepsize, expansion, depth, _params.perm_ratio);
 
 	logger().info() << "After knob building, rep size="

--- a/opencog/asmoses/moses/representation/representation.h
+++ b/opencog/asmoses/moses/representation/representation.h
@@ -57,7 +57,6 @@ struct representation : public knob_mapper, boost::noncopyable, boost::equality_
 	               const operator_set& ignore_ops = operator_set(),
 	               const combo_tree_ns_set* perceptions = NULL,
 	               const combo_tree_ns_set* actions = NULL,
-	               bool linear_contin = true,
 	               const representation_parameters& rp=representation_parameters());
 
 	/**

--- a/opencog/asmoses/moses/representation/representation.h
+++ b/opencog/asmoses/moses/representation/representation.h
@@ -55,8 +55,6 @@ struct representation : public knob_mapper, boost::noncopyable, boost::equality_
 	representation(const combo_tree& exemplar,
 	               const combo::type_tree& t,
 	               const operator_set& ignore_ops = operator_set(),
-	               const combo_tree_ns_set* perceptions = NULL,
-	               const combo_tree_ns_set* actions = NULL,
 	               const representation_parameters& rp=representation_parameters());
 
 	/**

--- a/opencog/asmoses/moses/representation/representation.h
+++ b/opencog/asmoses/moses/representation/representation.h
@@ -214,6 +214,10 @@ inline std::ostream& operator<<(std::ostream& out,
 }
 
 } //~namespace moses
+
+std::string oc_to_string(const moses::representation& rep,
+                         const std::string& indent=empty_string);
+
 } //~namespace opencog
 
 #endif

--- a/opencog/asmoses/moses/representation/representation.h
+++ b/opencog/asmoses/moses/representation/representation.h
@@ -29,6 +29,7 @@
 #include <opencog/asmoses/combo/type_checker/type_tree.h>
 #include <boost/operators.hpp>
 #include "knob_mapper.h"
+#include "representation_parameters.h"
 
 namespace opencog { namespace moses {
 
@@ -50,15 +51,14 @@ struct representation : public knob_mapper, boost::noncopyable, boost::equality_
 	typedef std::set<combo::combo_tree, size_tree_order<combo::vertex>> combo_tree_ns_set;
 
 	// Optional arguments are used only for actions/Petbrain
-	representation(const reduct::rule& simplify_candidate,
-	               const reduct::rule& simplify_knob_building,
-	               const combo_tree& exemplar_,
+	// NEXT
+	representation(const combo_tree& exemplar,
 	               const combo::type_tree& t,
 	               const operator_set& ignore_ops = operator_set(),
 	               const combo_tree_ns_set* perceptions = NULL,
 	               const combo_tree_ns_set* actions = NULL,
 	               bool linear_contin = true,
-	               float perm_ratio = 0.0);
+	               const representation_parameters& rp=representation_parameters());
 
 	/**
 	 * Turn the knobs on this representation, so that they have the same
@@ -113,13 +113,13 @@ struct representation : public knob_mapper, boost::noncopyable, boost::equality_
 		return this->_exemplar == other.exemplar();
 	}
 
-	//* return _simplify_candidate
-	const reduct::rule* get_simplify_candidate() const {
-		return _simplify_candidate;
+	//* Return reduction function used during optimization
+	const reduct::rule* opt_reduct() const {
+		return _params.opt_reduct;
 	}
-	//* return _simplify_knob_building
-	const reduct::rule* get_simplify_knob_building() const {
-		return _simplify_knob_building;
+	//* Return reduction function used during representation building
+	const reduct::rule* rep_reduct() const {
+		return _params.rep_reduct;
 	}
 
 	const field_set& fields() const {
@@ -192,8 +192,10 @@ struct representation : public knob_mapper, boost::noncopyable, boost::equality_
 	}
 
 protected:
-	combo_tree _exemplar;     // contains the prototype of the
-	// exemplar used to generate the deme
+	combo_tree _exemplar;     // Contains the prototype of the
+	                          // exemplar used to generate the deme
+
+	const representation_parameters& _params;
 
 #ifdef EXEMPLAR_INST_IS_UNDEAD
 	void set_exemplar_inst();
@@ -204,8 +206,6 @@ protected:
 #endif
 
 	field_set _fields;
-	const reduct::rule* _simplify_candidate; // used to simplify candidates
-	const reduct::rule* _simplify_knob_building; // used to simplify
 	// during knob
 	// building
 	mutable boost::mutex tranform_mutex;

--- a/opencog/asmoses/moses/representation/representation.h
+++ b/opencog/asmoses/moses/representation/representation.h
@@ -40,183 +40,182 @@ void set_depth(int new_depth);
  * determine the initial exemplar given its output type
  */
 combo_tree type_to_exemplar(type_node type);
-        
+
 /**
  * Do the representation-building, create a field_set
  */
 struct representation : public knob_mapper, boost::noncopyable, boost::equality_comparable<representation>
 {
-    typedef std::set<combo::vertex> operator_set;
-    typedef std::set<combo::combo_tree, size_tree_order<combo::vertex>>
-    combo_tree_ns_set;
+	typedef std::set<combo::vertex> operator_set;
+	typedef std::set<combo::combo_tree, size_tree_order<combo::vertex>> combo_tree_ns_set;
 
-    // Optional arguments are used only for actions/Petbrain
-    representation(const reduct::rule& simplify_candidate,
-                   const reduct::rule& simplify_knob_building,
-                   const combo_tree& exemplar_,
-                   const combo::type_tree& t,
-                   const operator_set& ignore_ops = operator_set(),
-                   const combo_tree_ns_set* perceptions = NULL,
-                   const combo_tree_ns_set* actions = NULL,
-                   bool linear_contin = true,
-                   float perm_ratio = 0.0);
+	// Optional arguments are used only for actions/Petbrain
+	representation(const reduct::rule& simplify_candidate,
+	               const reduct::rule& simplify_knob_building,
+	               const combo_tree& exemplar_,
+	               const combo::type_tree& t,
+	               const operator_set& ignore_ops = operator_set(),
+	               const combo_tree_ns_set* perceptions = NULL,
+	               const combo_tree_ns_set* actions = NULL,
+	               bool linear_contin = true,
+	               float perm_ratio = 0.0);
 
-    /**
-     * Turn the knobs on this representation, so that they have the same
-     * settings as those in the 'instance' argument.
-     */
-    void transform(const instance&);
+	/**
+	 * Turn the knobs on this representation, so that they have the same
+	 * settings as those in the 'instance' argument.
+	 */
+	void transform(const instance&);
 
-    /**
-     * Returns a clean and reduced version of the current exemplar.
-     * This would typically be called after turning some of its knobs.
-     *
-     * @param reduce whether the combo_tree is reduced before it is returned
-     * @param knob_building if true then _simplify_knob_building is used to
-     *                      reduce, otherwise (the default) _simplify_candidate.
-     * @return returns a copy of _exemplar, cleaned and reduced
-     */
-    combo_tree get_clean_exemplar(bool reduce, bool knob_building = false) const;
+	/**
+	 * Returns a clean and reduced version of the current exemplar.
+	 * This would typically be called after turning some of its knobs.
+	 *
+	 * @param reduce whether the combo_tree is reduced before it is returned
+	 * @param knob_building if true then _simplify_knob_building is used to
+	 *                      reduce, otherwise (the default) _simplify_candidate.
+	 * @return returns a copy of _exemplar, cleaned and reduced
+	 */
+	combo_tree get_clean_exemplar(bool reduce, bool knob_building = false) const;
 
-    /**
-     * Helper of get_clean_exemplar and get_candidate.
-     *
-     * Return a clean and possibly reduced version of tr. If knob_building
-     * is true then _simplify_knob_building is used to reduce, otherwise
-     * (the default) _simplify_candidate.
-     */
-    void clean_combo_tree(combo_tree &tr, bool reduce,
-                          bool knob_building = false) const;
+	/**
+	 * Helper of get_clean_exemplar and get_candidate.
+	 *
+	 * Return a clean and possibly reduced version of tr. If knob_building
+	 * is true then _simplify_knob_building is used to reduce, otherwise
+	 * (the default) _simplify_candidate.
+	 */
+	void clean_combo_tree(combo_tree &tr, bool reduce,
+	                      bool knob_building = false) const;
 
-    /**
-     * Thread safe composition of transform and
-     * get_clean_exemplar. Around for the time being just in case but
-     * should be removed eventually.
-     */
-    combo_tree get_candidate_lock(const instance& inst, bool reduce);
-    
-    /**
-     * Like get_candidate but without lock
-     */
-    combo_tree get_candidate(const instance& inst, bool reduce) const;
+	/**
+	 * Thread safe composition of transform and
+	 * get_clean_exemplar. Around for the time being just in case but
+	 * should be removed eventually.
+	 */
+	combo_tree get_candidate_lock(const instance& inst, bool reduce);
 
-    // recursive helper
-    void get_candidate_rec(const instance& inst,
-                           combo_tree::iterator src,
-                           combo_tree::iterator parent_dst,
-                           combo_tree& candidate) const;
+	/**
+	 * Like get_candidate but without lock
+	 */
+	combo_tree get_candidate(const instance& inst, bool reduce) const;
 
-    /**
-     * Compare two representations for equality by comparing the exemplars
-     * @return bool
-     */
-     bool operator==(const representation& other) const {
-     	return this->_exemplar == other.exemplar();
-     }
+	// recursive helper
+	void get_candidate_rec(const instance& inst,
+	                       combo_tree::iterator src,
+	                       combo_tree::iterator parent_dst,
+	                       combo_tree& candidate) const;
 
-    //* return _simplify_candidate
-    const reduct::rule* get_simplify_candidate() const {
-        return _simplify_candidate;
-    }
-    //* return _simplify_knob_building
-    const reduct::rule* get_simplify_knob_building() const {
-        return _simplify_knob_building;
-    }
+	/**
+	 * Compare two representations for equality by comparing the exemplars
+	 * @return bool
+	 */
+	bool operator==(const representation& other) const {
+		return this->_exemplar == other.exemplar();
+	}
 
-    const field_set& fields() const {
-        return _fields;
-    }
+	//* return _simplify_candidate
+	const reduct::rule* get_simplify_candidate() const {
+		return _simplify_candidate;
+	}
+	//* return _simplify_knob_building
+	const reduct::rule* get_simplify_knob_building() const {
+		return _simplify_knob_building;
+	}
 
-    field_set& fields() {
-        return _fields;
-    }
+	const field_set& fields() const {
+		return _fields;
+	}
 
-    const combo_tree& exemplar() const {
-        return _exemplar;
-    }
+	field_set& fields() {
+		return _fields;
+	}
+
+	const combo_tree& exemplar() const {
+		return _exemplar;
+	}
 
 #ifdef EXEMPLAR_INST_IS_UNDEAD
-    const instance& exemplar_inst() const {
-        return _exemplar_inst;
-    }
-    void clear_exemplar();
+	const instance& exemplar_inst() const {
+		return _exemplar_inst;
+	}
+	void clear_exemplar();
 #endif
 
-    /**
-     * Output the prototype of the exemplar (works correctly only when
-     * the exemplar is not yet changed).
-     */
-    template<typename Out>
-    Out& ostream_prototype(Out& out, combo_tree::iterator it) const
-    {
-        typedef combo_tree::sibling_iterator sib_it;
-        if (is_contin(*it)) { // contin
-            contin_map_cit c_cit = find_contin_knob(it);
-            out << (c_cit == contin.end() ? *it : c_cit->second.toStr());
-        } else { // disc
-            disc_map_cit d_cit = find_disc_knob(it);
-            out << (d_cit == disc.end() ? *it : d_cit->second->toStr());
-            if (d_cit != disc.end()) {
-                // In the case of action_subtree_knob just return. (it
-                // would be wrong to do a recursive call because it
-                // might be on the subtree that has alreaby been
-                // ostreamed). This is kinda hacky.
-                if (d_cit->second.type() == typeid(action_subtree_knob)) {
-                    return out;
-                }
-            }
-        }
+	/**
+	 * Output the prototype of the exemplar (works correctly only when
+	 * the exemplar is not yet changed).
+	 */
+	template<typename Out>
+	Out& ostream_prototype(Out& out, combo_tree::iterator it) const
+	{
+		typedef combo_tree::sibling_iterator sib_it;
+		if (is_contin(*it)) { // contin
+			contin_map_cit c_cit = find_contin_knob(it);
+			out << (c_cit == contin.end() ? *it : c_cit->second.toStr());
+		} else { // disc
+			disc_map_cit d_cit = find_disc_knob(it);
+			out << (d_cit == disc.end() ? *it : d_cit->second->toStr());
+			if (d_cit != disc.end()) {
+				// In the case of action_subtree_knob just return. (it
+				// would be wrong to do a recursive call because it
+				// might be on the subtree that has alreaby been
+				// ostreamed). This is kinda hacky.
+				if (d_cit->second.type() == typeid(action_subtree_knob)) {
+					return out;
+				}
+			}
+		}
 
-        // if null_vertex then print its child instead
-        if (*it == id::null_vertex) {
-            OC_ASSERT(it.has_one_child());
-            it = it.begin();
-        }
+		// if null_vertex then print its child instead
+		if (*it == id::null_vertex) {
+			OC_ASSERT(it.has_one_child());
+			it = it.begin();
+		}
 
-        // recursive call on children
-        if (not it.is_childless()) {
-            out << "(";
-            for (sib_it sib = it.begin(); sib != it.end();) {
-                ostream_prototype(out, sib);
-                if (++sib != it.end()) out << " ";
-            }
-            out << ")";
-        }
-        return out;
-    }
+		// recursive call on children
+		if (not it.is_childless()) {
+			out << "(";
+			for (sib_it sib = it.begin(); sib != it.end();) {
+				ostream_prototype(out, sib);
+				if (++sib != it.end()) out << " ";
+			}
+			out << ")";
+		}
+		return out;
+	}
 
-    // like above but on the _exemplar
-    template<typename Out>
-    Out& ostream_prototype(Out& out) const
-    {
-        return ostream_prototype(out, _exemplar.begin());
-    }
+	// like above but on the _exemplar
+	template<typename Out>
+	Out& ostream_prototype(Out& out) const
+	{
+		return ostream_prototype(out, _exemplar.begin());
+	}
 
 protected:
-    combo_tree _exemplar;     // contains the prototype of the
-                              // exemplar used to generate the deme
+	combo_tree _exemplar;     // contains the prototype of the
+	// exemplar used to generate the deme
 
 #ifdef EXEMPLAR_INST_IS_UNDEAD
-    void set_exemplar_inst();
-    instance _exemplar_inst; // instance corresponding to the exemplar
-                             // @todo: it is not sure whether we need
-                             // that because it is assumed that the
-                             // instance of the exemplar is null
+	void set_exemplar_inst();
+	instance _exemplar_inst; // instance corresponding to the exemplar
+	// @todo: it is not sure whether we need
+	// that because it is assumed that the
+	// instance of the exemplar is null
 #endif
 
-    field_set _fields;
-    const reduct::rule* _simplify_candidate; // used to simplify candidates
-    const reduct::rule* _simplify_knob_building; // used to simplify
-                                                 // during knob
-                                                 // building
-    mutable boost::mutex tranform_mutex;
+	field_set _fields;
+	const reduct::rule* _simplify_candidate; // used to simplify candidates
+	const reduct::rule* _simplify_knob_building; // used to simplify
+	// during knob
+	// building
+	mutable boost::mutex tranform_mutex;
 };
 
 // This helper seems to be needed to unconfuse the compiler.
 inline std::ostream& operator<<(std::ostream& out,
                                 const opencog::moses::representation& r)
 {
-    return r.ostream_prototype(out);
+	return r.ostream_prototype(out);
 }
 
 } //~namespace moses

--- a/opencog/asmoses/moses/representation/representation.h
+++ b/opencog/asmoses/moses/representation/representation.h
@@ -51,10 +51,8 @@ struct representation : public knob_mapper, boost::noncopyable, boost::equality_
 	typedef std::set<combo::combo_tree, size_tree_order<combo::vertex>> combo_tree_ns_set;
 
 	// Optional arguments are used only for actions/Petbrain
-	// NEXT
 	representation(const combo_tree& exemplar,
-	               const combo::type_tree& t,
-	               const operator_set& ignore_ops = operator_set(),
+	               const combo::type_tree& tt,
 	               const representation_parameters& rp=representation_parameters());
 
 	/**
@@ -72,7 +70,7 @@ struct representation : public knob_mapper, boost::noncopyable, boost::equality_
 	 *                      reduce, otherwise (the default) _simplify_candidate.
 	 * @return returns a copy of _exemplar, cleaned and reduced
 	 */
-	combo_tree get_clean_exemplar(bool reduce, bool knob_building = false) const;
+	combo_tree get_clean_exemplar(bool reduce, bool knob_building=false) const;
 
 	/**
 	 * Helper of get_clean_exemplar and get_candidate.
@@ -82,7 +80,7 @@ struct representation : public knob_mapper, boost::noncopyable, boost::equality_
 	 * (the default) _simplify_candidate.
 	 */
 	void clean_combo_tree(combo_tree &tr, bool reduce,
-	                      bool knob_building = false) const;
+	                      bool knob_building=false) const;
 
 	/**
 	 * Thread safe composition of transform and
@@ -192,7 +190,7 @@ protected:
 	combo_tree _exemplar;     // Contains the prototype of the
 	                          // exemplar used to generate the deme
 
-	const representation_parameters& _params;
+	representation_parameters _params;
 
 #ifdef EXEMPLAR_INST_IS_UNDEAD
 	void set_exemplar_inst();
@@ -203,8 +201,8 @@ protected:
 #endif
 
 	field_set _fields;
-	// during knob
-	// building
+
+	// During knob building
 	mutable boost::mutex tranform_mutex;
 };
 

--- a/opencog/asmoses/moses/representation/representation_parameters.h
+++ b/opencog/asmoses/moses/representation/representation_parameters.h
@@ -25,6 +25,8 @@
 
 namespace opencog { namespace moses {
 
+static const operator_set empty_ignore_ops = operator_set();
+
 enum class knob_probing_enum {
 	kp_auto,
 	kp_on,
@@ -53,6 +55,7 @@ struct representation_parameters
 {
 	representation_parameters(reduct::rule* opt_red=NULL,
 	                          reduct::rule* rep_red=NULL,
+	                          const operator_set& igops=empty_ignore_ops,
 	                          knob_probing_enum kp=knob_probing_enum::kp_auto,
 	                          bool linc=false,
 	                          float permr=0.0,
@@ -60,6 +63,7 @@ struct representation_parameters
 	                          const combo_tree_ns_set* acts=nullptr)
 		: opt_reduct(opt_red),
 		  rep_reduct(rep_red),
+		  ignore_ops(igops),
 		  knob_probing(kp),
 		  linear_contin(linc),
 		  perm_ratio(permr),
@@ -72,6 +76,9 @@ struct representation_parameters
 
 	// Reduction for representation
 	const reduct::rule* rep_reduct;
+
+	// Set of operators to ignore
+	operator_set ignore_ops;
 
 	// Whether knob probing is auto, on or off
 	knob_probing_enum knob_probing;

--- a/opencog/asmoses/moses/representation/representation_parameters.h
+++ b/opencog/asmoses/moses/representation/representation_parameters.h
@@ -54,18 +54,38 @@ struct representation_parameters
 	representation_parameters(reduct::rule* opt_red=NULL,
 	                          reduct::rule* rep_red=NULL,
 	                          knob_probing_enum kp=knob_probing_enum::kp_auto,
+	                          bool lc=false,
 	                          float pr=0.0)
 		: opt_reduct(opt_red),
 		  rep_reduct(rep_red),
 		  knob_probing(kp),
+		  linear_contin(lc),
 		  perm_ratio(pr)
 		{}
 
-	// NEXT: better comment
-	const reduct::rule* opt_reduct;  // Reduction during optimization
-	const reduct::rule* rep_reduct;  // Reduction for representation
-	knob_probing_enum knob_probing;  // Whether knob probing is auto, on or off
-	float perm_ratio;                // Permutation ratio of logical knobs
+	// Reduction during optimization
+	const reduct::rule* opt_reduct;
+
+	// Reduction for representation
+	const reduct::rule* rep_reduct;
+
+	// Whether knob probing is auto, on or off
+	knob_probing_enum knob_probing;
+
+	// Build only linear expressions involving contin features.
+	// This can greatly decrease the number of knobs created during
+	// representation building, resulting in much smaller field sets,
+	// and instances that can be searched more quickly. However, in
+	// order to fit the data, linear expressions may not be as good,
+	// and thus may require more time overall to find...
+	bool linear_contin;
+
+	// Defines how many pairs of literals constituting subtrees op(l1
+	// l2) are considered while creating the prototype of an
+	// exemplar. It ranges from 0 to 1, 0 means arity positive
+	// literals and arity pairs of literals, 1 means arity positive
+	// literals and arity*(arity-1) pairs of literals
+	float perm_ratio;
 };
 
 } // ~namespace moses

--- a/opencog/asmoses/moses/representation/representation_parameters.h
+++ b/opencog/asmoses/moses/representation/representation_parameters.h
@@ -54,13 +54,17 @@ struct representation_parameters
 	representation_parameters(reduct::rule* opt_red=NULL,
 	                          reduct::rule* rep_red=NULL,
 	                          knob_probing_enum kp=knob_probing_enum::kp_auto,
-	                          bool lc=false,
-	                          float pr=0.0)
+	                          bool linc=false,
+	                          float permr=0.0,
+	                          const combo_tree_ns_set* prcts=nullptr,
+	                          const combo_tree_ns_set* acts=nullptr)
 		: opt_reduct(opt_red),
 		  rep_reduct(rep_red),
 		  knob_probing(kp),
-		  linear_contin(lc),
-		  perm_ratio(pr)
+		  linear_contin(linc),
+		  perm_ratio(permr),
+		  perceptions(prcts),
+		  actions(acts)
 		{}
 
 	// Reduction during optimization
@@ -86,6 +90,12 @@ struct representation_parameters
 	// literals and arity pairs of literals, 1 means arity positive
 	// literals and arity*(arity-1) pairs of literals
 	float perm_ratio;
+
+	// Set or perceptions and actions.  Only used for procedural
+	// learning, nullptr otherwise.
+	const combo_tree_ns_set* perceptions;
+	const combo_tree_ns_set* actions;
+
 };
 
 } // ~namespace moses

--- a/opencog/asmoses/moses/representation/representation_parameters.h
+++ b/opencog/asmoses/moses/representation/representation_parameters.h
@@ -61,8 +61,8 @@ struct representation_parameters
 	                          knob_probing_enum kp=knob_probing_enum::kp_auto,
 	                          bool linc=false,
 	                          float permr=0.0,
-	                          const combo_tree_ns_set* prcts=nullptr,
-	                          const combo_tree_ns_set* acts=nullptr)
+	                          const combo::combo_tree_ns_set* prcts=nullptr,
+	                          const combo::combo_tree_ns_set* acts=nullptr)
 		: opt_reduct(opt_red),
 		  rep_reduct(rep_red),
 		  ignore_ops(igops),
@@ -102,8 +102,8 @@ struct representation_parameters
 
 	// Set or perceptions and actions.  Only used for procedural
 	// learning, nullptr otherwise.
-	const combo_tree_ns_set* perceptions;
-	const combo_tree_ns_set* actions;
+	const combo::combo_tree_ns_set* perceptions;
+	const combo::combo_tree_ns_set* actions;
 
 };
 

--- a/opencog/asmoses/moses/representation/representation_parameters.h
+++ b/opencog/asmoses/moses/representation/representation_parameters.h
@@ -23,9 +23,11 @@
 #ifndef _OPENCOG_REPRESENTATION_PARAMETERS_H
 #define _OPENCOG_REPRESENTATION_PARAMETERS_H
 
+#include <opencog/asmoses/combo/combo/vertex.h>
+
 namespace opencog { namespace moses {
 
-static const operator_set empty_ignore_ops = operator_set();
+static const combo::operator_set empty_ignore_ops = combo::operator_set();
 
 enum class knob_probing_enum {
 	kp_auto,
@@ -55,7 +57,7 @@ struct representation_parameters
 {
 	representation_parameters(reduct::rule* opt_red=NULL,
 	                          reduct::rule* rep_red=NULL,
-	                          const operator_set& igops=empty_ignore_ops,
+	                          const combo::operator_set& igops=empty_ignore_ops,
 	                          knob_probing_enum kp=knob_probing_enum::kp_auto,
 	                          bool linc=false,
 	                          float permr=0.0,
@@ -78,7 +80,7 @@ struct representation_parameters
 	const reduct::rule* rep_reduct;
 
 	// Set of operators to ignore
-	operator_set ignore_ops;
+	combo::operator_set ignore_ops;
 
 	// Whether knob probing is auto, on or off
 	knob_probing_enum knob_probing;

--- a/opencog/asmoses/moses/representation/representation_parameters.h
+++ b/opencog/asmoses/moses/representation/representation_parameters.h
@@ -1,0 +1,74 @@
+/** representation_params.h ---
+ *
+ * Copyright (C) 2022 SingularityNET Foundation
+ *
+ * Author: Nil Geisweiller
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef _OPENCOG_REPRESENTATION_PARAMETERS_H
+#define _OPENCOG_REPRESENTATION_PARAMETERS_H
+
+namespace opencog { namespace moses {
+
+enum class knob_probing_enum {
+	kp_auto,
+	kp_on,
+	kp_off
+};
+
+static inline knob_probing_enum parse_knob_probing(std::string& kp_str)
+{
+	knob_probing_enum kp = knob_probing_enum::kp_auto;
+	if (kp_str == "auto")
+		kp = knob_probing_enum::kp_auto;
+	else if (kp_str == "0")
+		kp = knob_probing_enum::kp_on;
+	else if (kp_str == "1")
+		kp = knob_probing_enum::kp_off;
+	else
+		OC_ASSERT(false, "Knob probing option %s not supported",
+		          kp_str.c_str());
+	return kp;
+}
+
+/**
+ * Parameters for representation building
+ */
+struct representation_parameters
+{
+	representation_parameters(reduct::rule* opt_red=NULL,
+	                          reduct::rule* rep_red=NULL,
+	                          knob_probing_enum kp=knob_probing_enum::kp_auto,
+	                          float pr=0.0)
+		: opt_reduct(opt_red),
+		  rep_reduct(rep_red),
+		  knob_probing(kp),
+		  perm_ratio(pr)
+		{}
+
+	// NEXT: better comment
+	const reduct::rule* opt_reduct;  // Reduction during optimization
+	const reduct::rule* rep_reduct;  // Reduction for representation
+	knob_probing_enum knob_probing;  // Whether knob probing is auto, on or off
+	float perm_ratio;                // Permutation ratio of logical knobs
+};
+
+} // ~namespace moses
+} // ~namespace opencog
+
+#endif // _OPENCOG_REPRESENTATIOB_PARAMETERS_H

--- a/opencog/asmoses/moses/representation/representation_parameters.h
+++ b/opencog/asmoses/moses/representation/representation_parameters.h
@@ -40,9 +40,9 @@ static inline knob_probing_enum parse_knob_probing(std::string& kp_str)
 	knob_probing_enum kp = knob_probing_enum::kp_auto;
 	if (kp_str == "auto")
 		kp = knob_probing_enum::kp_auto;
-	else if (kp_str == "0")
+	else if (kp_str == "1" or kp_str == "on")
 		kp = knob_probing_enum::kp_on;
-	else if (kp_str == "1")
+	else if (kp_str == "0" or kp_str == "off")
 		kp = knob_probing_enum::kp_off;
 	else
 		OC_ASSERT(false, "Knob probing option %s not supported",

--- a/tests/moses/moses/AntUTest.cxxtest
+++ b/tests/moses/moses/AntUTest.cxxtest
@@ -48,9 +48,9 @@ class AntUTest : public CxxTest::TestSuite
 public:
     AntUTest() {
         // Logger setting
-        logger().set_print_to_stdout_flag(true); 
-        // logger().set_level(Logger::DEBUG);        
-        logger().set_level(Logger::INFO);        
+        logger().set_print_to_stdout_flag(true);
+        // logger().set_level(Logger::DEBUG);
+        logger().set_level(Logger::INFO);
     }
 
     void test_ant() {

--- a/tests/moses/moses/AntUTest.cxxtest
+++ b/tests/moses/moses/AntUTest.cxxtest
@@ -89,10 +89,10 @@ public:
         representation_parameters rep_params;
         rep_params.opt_reduct = &action_reduction();
         rep_params.rep_reduct = &action_reduction();
+        rep_params.perceptions = &perceptions;
+        rep_params.actions = &actions;
 
         deme_parameters deme_params;
-        deme_params.perceptions = &perceptions;
-        deme_params.actions = &actions;
 
         metapop_parameters meta_params;
         meta_params.complexity_temperature = 2000;  // See diary entry

--- a/tests/moses/moses/AntUTest.cxxtest
+++ b/tests/moses/moses/AntUTest.cxxtest
@@ -86,12 +86,16 @@ public:
 
         perceptions.insert(combo_tree(get_instance(id::is_food_ahead)));
 
-        deme_parameters demeparms;
-        demeparms.perceptions = &perceptions;
-        demeparms.actions = &actions;
+        representation_parameters rep_params;
+        rep_params.opt_reduct = &action_reduction();
+        rep_params.rep_reduct = &action_reduction();
 
-        metapop_parameters metaparms;
-        metaparms.complexity_temperature = 2000;  // See diary entry
+        deme_parameters deme_params;
+        deme_params.perceptions = &perceptions;
+        deme_params.actions = &actions;
+
+        metapop_parameters meta_params;
+        meta_params.complexity_temperature = 2000;  // See diary entry
 
         // Define optimization algo
         optim_parameters opt_params;
@@ -100,16 +104,15 @@ public:
         hc_params.crossover = true;      // Same as default
         hill_climbing hc(opt_params, hc_params);
 
-        deme_expander dex(tt, action_reduction(),
-                              action_reduction(), cscorer, hc, demeparms);
+        deme_expander dex(tt, cscorer, hc, deme_params, rep_params);
         metapopulation metapop(combo_tree(id::sequential_and),
-                               cscorer, metaparms);
-  
+                               cscorer, meta_params);
+
         boost::program_options::variables_map vm;
 
-        moses_parameters moses_param(vm, jobs, true, max_evals, -1, 0, 100);
+        moses_parameters moses_params(vm, jobs, true, max_evals, -1, 0, 100);
         moses_statistics st;
-        run_moses(metapop, dex, moses_param, st);
+        run_moses(metapop, dex, moses_params, st);
         TS_ASSERT_EQUALS(metapop.best_score(), 0.0);
     }
 };

--- a/tests/moses/representation/AtomeseRepresentationUTest.cxxtest
+++ b/tests/moses/representation/AtomeseRepresentationUTest.cxxtest
@@ -75,10 +75,11 @@ public:
 
 		const HandleSet ignore_ops;
 		logical_reduction r(ignore_ops);
-		const rule& r2 = r.operator()(2);
-		const rule& r0 = r.operator()(0);
+		representation_parameters rep_params;
+		rep_params.opt_reduct = &r.operator()(2);
+		rep_params.rep_reduct = &r.operator()(0);
 
-		AtomeseRepresentation rep(r2, r0, exemplar, type, _as, ignore_ops);
+		AtomeseRepresentation rep(exemplar, type, _as, ignore_ops, rep_params);
 
 		field_set fields = rep.fields();
 		// about 22 knobs are expected
@@ -95,10 +96,11 @@ public:
 
 		const HandleSet ignore_ops;
 		logical_reduction r(ignore_ops);
-		const rule& r2 = r.operator()(2);
-		const rule& r0 = r.operator()(0);
+		representation_parameters rep_params;
+		rep_params.opt_reduct = &r.operator()(2);
+		rep_params.rep_reduct = &r.operator()(0);
 
-		AtomeseRepresentation rep(r2, r0, exemplar, type, _as, ignore_ops);
+		AtomeseRepresentation rep(exemplar, type, _as, ignore_ops, rep_params);
 
 		field_set fields = rep.fields();
 		// about 30 knobs are expected
@@ -124,10 +126,11 @@ public:
 
 		const HandleSet ignore_ops;
 		logical_reduction r(ignore_ops);
-		const rule& r2 = r.operator()(2);
-		const rule& r0 = r.operator()(0);
+		representation_parameters rep_params;
+		rep_params.opt_reduct = &r.operator()(2);
+		rep_params.rep_reduct = &r.operator()(0);
 
-		AtomeseRepresentation rep(r2, r0, exemplar, type, _as, ignore_ops);
+		AtomeseRepresentation rep(exemplar, type, _as, ignore_ops, rep_params);
 
 		field_set fields = rep.fields();
 		// about 69 knobs are expected
@@ -143,10 +146,11 @@ public:
 
 		const HandleSet ignore_ops;
 		logical_reduction r(ignore_ops);
-		const rule& r2 = r.operator()(2);
-		const rule& r0 = r.operator()(0);
+		representation_parameters rep_params;
+		rep_params.opt_reduct = &r.operator()(2);
+		rep_params.rep_reduct = &r.operator()(0);
 
-		AtomeseRepresentation rep(r2, r0, exemplar, type, _as, ignore_ops);
+		AtomeseRepresentation rep(exemplar, type, _as, ignore_ops, rep_params);
 
 		field_set fields = rep.fields();
 		// about 4 knobs are expected
@@ -182,10 +186,11 @@ public:
 
 		const HandleSet ignore_ops;
 		logical_reduction r(ignore_ops);
-		const rule& r2 = r.operator()(2);
-		const rule& r0 = r.operator()(0);
+		representation_parameters rep_params;
+		rep_params.opt_reduct = &r.operator()(2);
+		rep_params.rep_reduct = &r.operator()(0);
 
-		AtomeseRepresentation rep(r2, r0, exemplar, type, _as, ignore_ops);
+		AtomeseRepresentation rep(exemplar, type, _as, ignore_ops, rep_params);
 
 		field_set fields = rep.fields();
 		// about 178 knobs are expected
@@ -205,10 +210,12 @@ public:
 
 		const HandleSet ignore_ops;
 		logical_reduction r(ignore_ops);
-		const rule& r2 = r.operator()(2);
-		const rule& r3 = r.operator()(3);
+		representation_parameters rep_params;
+		rep_params.opt_reduct = &r.operator()(2);
+		rep_params.rep_reduct = &r.operator()(3);
+		rep_params.perm_ratio = 1.0;
 
-		AtomeseRepresentation rep(r2, r3, exemplar, type, _as, ignore_ops, 1);
+		AtomeseRepresentation rep(exemplar, type, _as, ignore_ops, rep_params);
 
 		field_set fields = rep.fields();
 		// about 36 knobs are expected.
@@ -236,9 +243,11 @@ public:
 
 		const HandleSet ignore_ops;
 		logical_reduction r(ignore_ops);
-		const rule& r2 = r.operator()(2);
+		representation_parameters rep_params;
+		rep_params.opt_reduct = &r.operator()(2);
+		rep_params.rep_reduct = &r.operator()(2);
 
-		AtomeseRepresentation rep(r2, r2, exemplar, type, _as, ignore_ops);
+		AtomeseRepresentation rep(exemplar, type, _as, ignore_ops, rep_params);
 
 		field_set fields = rep.fields();
 		// expect about ~27 knobs [apparently depends on reduct]
@@ -255,10 +264,10 @@ public:
 		const HandleSet ignore_ops = {createNode(TYPE_NODE, "SinLink"),
 		                              createNode(TYPE_NODE, "LogLink"),
 		                              createNode(TYPE_NODE, "ExpLink")};
-		AtomeseRepresentation rep(contin_reduction(2, ignore_ops),
-		                           contin_reduction(2, ignore_ops),
-		                           exemplar, type, _as, ignore_ops,
-		                           0.0);
+		representation_parameters rep_params;
+		rep_params.opt_reduct = &contin_reduction(2, ignore_ops);
+		rep_params.rep_reduct = &contin_reduction(2, ignore_ops);
+		AtomeseRepresentation rep(exemplar, type, _as, ignore_ops, rep_params);
 
 		field_set fields = rep.fields();
 		TS_ASSERT_EQUALS(7, fields.contin().size());
@@ -286,10 +295,10 @@ public:
 		const HandleSet ignore_ops = {createNode(TYPE_NODE, "SinLink"),
 		                              createNode(TYPE_NODE, "LogLink"),
 		                              createNode(TYPE_NODE, "ExpLink")};
-		AtomeseRepresentation rep(contin_reduction(2, ignore_ops),
-		                           contin_reduction(2, ignore_ops),
-		                           exemplar, type, _as, ignore_ops,
-		                           0.0);
+		representation_parameters rep_params;
+		rep_params.opt_reduct = &contin_reduction(2, ignore_ops);
+		rep_params.rep_reduct = &contin_reduction(2, ignore_ops);
+		AtomeseRepresentation rep(exemplar, type, _as, ignore_ops, rep_params);
 
 		field_set fields = rep.fields();
 		TS_ASSERT_EQUALS(14, fields.contin().size());
@@ -303,10 +312,10 @@ public:
 				   an(SCHEMA_NODE, "$1"));
 		Handle type = infer_atomese_type(exemplar);
 		const HandleSet ignore_ops;
-		AtomeseRepresentation rep(contin_reduction(2, ignore_ops),
-		                           contin_reduction(2, ignore_ops),
-		                           exemplar, type, _as, ignore_ops,
-		                           0.0);
+		representation_parameters rep_params;
+		rep_params.opt_reduct = &contin_reduction(2, ignore_ops);
+		rep_params.rep_reduct = &contin_reduction(2, ignore_ops);
+		AtomeseRepresentation rep(exemplar, type, _as, ignore_ops, rep_params);
 
 		field_set fields = rep.fields();
 		TS_ASSERT_EQUALS(19, fields.contin().size());
@@ -320,10 +329,10 @@ public:
 				   an(SCHEMA_NODE, "$1"));
 		Handle type = infer_atomese_type(exemplar);
 		const HandleSet ignore_ops;
-		AtomeseRepresentation rep(contin_reduction(2, ignore_ops),
-		                           contin_reduction(2, ignore_ops),
-		                           exemplar, type, _as, ignore_ops,
-		                           0.0, false);
+		representation_parameters rep_params;
+		rep_params.opt_reduct = &contin_reduction(2, ignore_ops);
+		rep_params.rep_reduct = &contin_reduction(2, ignore_ops);
+		AtomeseRepresentation rep(exemplar, type, _as, ignore_ops, rep_params);
 
 		field_set fields = rep.fields();
 		TS_ASSERT_EQUALS(26, fields.contin().size());
@@ -349,10 +358,10 @@ public:
 				      an(SCHEMA_NODE, "$2")));
 		Handle type = infer_atomese_type(exemplar);
 		const HandleSet ignore_ops;
-		AtomeseRepresentation rep(contin_reduction(2, ignore_ops),
-		                           contin_reduction(2, ignore_ops),
-		                           exemplar, type, _as, ignore_ops,
-		                           0.0, false);
+		representation_parameters rep_params;
+		rep_params.opt_reduct = &contin_reduction(2, ignore_ops);
+		rep_params.rep_reduct = &contin_reduction(2, ignore_ops);
+		AtomeseRepresentation rep(exemplar, type, _as, ignore_ops, rep_params);
 
 		field_set fields = rep.fields();
 		TS_ASSERT_EQUALS(99, fields.contin().size());
@@ -366,9 +375,10 @@ public:
 		Handle type = infer_atomese_type(exemplar);
 		const HandleSet ignore_ops;
 		logical_reduction r(ignore_ops);
-		const rule& r2 = r.operator()(2);
-		const rule& r0 = r.operator()(0);
-		AtomeseRepresentation rep(r2, r0, exemplar, type, _as, ignore_ops);
+		representation_parameters rep_params;
+		rep_params.opt_reduct = &r.operator()(2);
+		rep_params.rep_reduct = &r.operator()(0);
+		AtomeseRepresentation rep(exemplar, type, _as, ignore_ops, rep_params);
 
 		field_set fields = rep.fields();
 		TS_ASSERT_LESS_THAN(0, fields.raw_size());
@@ -385,9 +395,10 @@ public:
 		Handle type = infer_atomese_type(exemplar);
 		const HandleSet ignore_ops;
 		logical_reduction r(ignore_ops);
-		const rule& r2 = r.operator()(2);
-		const rule& r0 = r.operator()(0);
-		AtomeseRepresentation rep(r2, r0, exemplar, type, _as, ignore_ops);
+		representation_parameters rep_params;
+		rep_params.opt_reduct = &r.operator()(2);
+		rep_params.rep_reduct = &r.operator()(0);
+		AtomeseRepresentation rep(exemplar, type, _as, ignore_ops, rep_params);
 
 		field_set fields = rep.fields();
 		TS_ASSERT_LESS_THAN(0, fields.raw_size());

--- a/tests/moses/representation/AtomeseRepresentationUTest.cxxtest
+++ b/tests/moses/representation/AtomeseRepresentationUTest.cxxtest
@@ -254,7 +254,7 @@ public:
 		TS_ASSERT_LESS_THAN(0, fields.raw_size());
 	}
 
-	void test_simple_contin_1()
+	void test_linear_contin_1()
 	{
 		Handle exemplar =
 				al(PLUS_LINK,
@@ -267,13 +267,14 @@ public:
 		representation_parameters rep_params;
 		rep_params.opt_reduct = &contin_reduction(2, ignore_ops);
 		rep_params.rep_reduct = &contin_reduction(2, ignore_ops);
+		rep_params.linear_contin = true;
 		AtomeseRepresentation rep(exemplar, type, _as, ignore_ops, rep_params);
-
+ 
 		field_set fields = rep.fields();
 		TS_ASSERT_EQUALS(7, fields.contin().size());
 	}
 
-	void test_simple_contin_2()
+	void test_linear_contin_2()
 	{
 		Handle exemplar =
 				al(DIVIDE_LINK,
@@ -298,13 +299,14 @@ public:
 		representation_parameters rep_params;
 		rep_params.opt_reduct = &contin_reduction(2, ignore_ops);
 		rep_params.rep_reduct = &contin_reduction(2, ignore_ops);
+		rep_params.linear_contin = true;
 		AtomeseRepresentation rep(exemplar, type, _as, ignore_ops, rep_params);
 
 		field_set fields = rep.fields();
 		TS_ASSERT_EQUALS(14, fields.contin().size());
 	}
 
-	void test_contin_SLE()
+	void test_linear_contin_SLE()
 	{
 		Handle exemplar =
 				al(PLUS_LINK,
@@ -315,6 +317,7 @@ public:
 		representation_parameters rep_params;
 		rep_params.opt_reduct = &contin_reduction(2, ignore_ops);
 		rep_params.rep_reduct = &contin_reduction(2, ignore_ops);
+		rep_params.linear_contin = true;
 		AtomeseRepresentation rep(exemplar, type, _as, ignore_ops, rep_params);
 
 		field_set fields = rep.fields();
@@ -367,7 +370,7 @@ public:
 		TS_ASSERT_EQUALS(99, fields.contin().size());
 	}
 
-	void test_mixed_1()
+	void test_linear_mixed_1()
 	{
 		Handle exemplar =
 				al(GREATER_THAN_LINK,
@@ -378,6 +381,7 @@ public:
 		representation_parameters rep_params;
 		rep_params.opt_reduct = &r.operator()(2);
 		rep_params.rep_reduct = &r.operator()(0);
+		rep_params.linear_contin = true;
 		AtomeseRepresentation rep(exemplar, type, _as, ignore_ops, rep_params);
 
 		field_set fields = rep.fields();
@@ -385,7 +389,7 @@ public:
 		TS_ASSERT_EQUALS(28, fields.contin().size());
 	}
 
-	void test_mixed_2()
+	void test_linear_mixed_2()
 	{
 		Handle exemplar =
 				al(AND_LINK,
@@ -398,6 +402,7 @@ public:
 		representation_parameters rep_params;
 		rep_params.opt_reduct = &r.operator()(2);
 		rep_params.rep_reduct = &r.operator()(0);
+		rep_params.linear_contin = true;
 		AtomeseRepresentation rep(exemplar, type, _as, ignore_ops, rep_params);
 
 		field_set fields = rep.fields();

--- a/tests/moses/representation/representationUTest.cxxtest
+++ b/tests/moses/representation/representationUTest.cxxtest
@@ -67,7 +67,8 @@ public:
         representation_parameters rep_params;
         rep_params.opt_reduct = &contin_reduction(reduct_effort, ignore_ops);
         rep_params.rep_reduct = &contin_reduction(reduct_effort, ignore_ops);
-        representation rep(tr, tt, ignore_ops, rep_params);
+        rep_params.ignore_ops = ignore_ops;
+        representation rep(tr, tt, rep_params);
 
         TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
 
@@ -89,8 +90,9 @@ public:
         representation_parameters rep_params;
         rep_params.opt_reduct = &contin_reduction(reduct_effort, ignore_ops);
         rep_params.rep_reduct = &contin_reduction(reduct_effort, ignore_ops);
+        rep_params.ignore_ops = ignore_ops;
         rep_params.linear_contin = true;
-        representation rep(tr, tt, ignore_ops, rep_params);
+        representation rep(tr, tt, rep_params);
 
         TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
 
@@ -116,7 +118,7 @@ public:
         rep_params.perm_ratio = 1.0; // all permutation are generated,
                                      // that way we avoid sampling
 
-        representation rep(tr, tt, vertex_set(), rep_params);
+        representation rep(tr, tt, rep_params);
 
         TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
 
@@ -142,7 +144,7 @@ public:
         rep_params.opt_reduct = &r.operator()(2);
         rep_params.rep_reduct = &r.operator()(2);
 
-        representation rep(tr, tt, vertex_set(), rep_params);
+        representation rep(tr, tt, rep_params);
 
         TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
     }
@@ -159,7 +161,7 @@ public:
         rep_params.opt_reduct = &r.operator()(2);
         rep_params.rep_reduct = &r.operator()(2);
 
-        representation rep(tr, tt, vertex_set(), rep_params);
+        representation rep(tr, tt, rep_params);
 
         TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
     }
@@ -176,7 +178,7 @@ public:
         rep_params.opt_reduct = &r.operator()(2);
         rep_params.rep_reduct = &r.operator()(2);
 
-        representation rep(tr, tt, vertex_set(), rep_params);
+        representation rep(tr, tt, rep_params);
 
         TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
     }
@@ -193,7 +195,7 @@ public:
         rep_params.opt_reduct = &r.operator()(2);
         rep_params.rep_reduct = &r.operator()(0);
 
-        representation rep(tr, tt, vertex_set(), rep_params);
+        representation rep(tr, tt, rep_params);
 
         TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
     }

--- a/tests/moses/representation/representationUTest.cxxtest
+++ b/tests/moses/representation/representationUTest.cxxtest
@@ -55,8 +55,8 @@ public:
 		logger().set_level(Logger::DEBUG);
 	}
 
-	// these tests are just here to check that the representation
-	// building does not crash, for now at least
+	// Most of these tests are just here to check that the
+	// representation building does not crash.
 
 	void test_contin_rep()
 	{
@@ -199,5 +199,43 @@ public:
 		representation rep(tr, tt, rep_params);
 
 		TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
+	}
+
+	void test_knob_probing_off()
+	{
+		string tr_str = "or(and(!$1 !$2) and($1 $2))";
+		combo_tree tr = totree(tr_str);
+		type_tree tt = infer_type_tree(tr);
+
+		const vertex_set ignore_ops;
+		logical_reduction r(ignore_ops);
+		representation_parameters rep_params;
+		rep_params.opt_reduct = &r.operator()(2);
+		rep_params.rep_reduct = &r.operator()(2);
+		rep_params.knob_probing = knob_probing_enum::kp_off;
+		rep_params.perm_ratio = 1.0; // For determinisic representation
+
+		representation rep(tr, tt, rep_params);
+
+		TS_ASSERT_EQUALS(44, rep.fields().raw_size());
+	}
+
+	void test_knob_probing_on()
+	{
+		string tr_str = "or(and(!$1 !$2) and($1 $2))";
+		combo_tree tr = totree(tr_str);
+		type_tree tt = infer_type_tree(tr);
+
+		const vertex_set ignore_ops;
+		logical_reduction r(ignore_ops);
+		representation_parameters rep_params;
+		rep_params.opt_reduct = &r.operator()(2);
+		rep_params.rep_reduct = &r.operator()(2);
+		rep_params.knob_probing = knob_probing_enum::kp_auto;
+		rep_params.perm_ratio = 1.0; // For determinisic representation
+
+		representation rep(tr, tt, rep_params);
+
+		TS_ASSERT_EQUALS(5, rep.fields().raw_size());
 	}
 };

--- a/tests/moses/representation/representationUTest.cxxtest
+++ b/tests/moses/representation/representationUTest.cxxtest
@@ -67,7 +67,7 @@ public:
         representation_parameters rep_params;
         rep_params.opt_reduct = &contin_reduction(reduct_effort, ignore_ops);
         rep_params.rep_reduct = &contin_reduction(reduct_effort, ignore_ops);
-        representation rep(tr, tt, ignore_ops, NULL, NULL, false, rep_params);
+        representation rep(tr, tt, ignore_ops, NULL, NULL, rep_params);
 
         TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
 
@@ -89,7 +89,8 @@ public:
         representation_parameters rep_params;
         rep_params.opt_reduct = &contin_reduction(reduct_effort, ignore_ops);
         rep_params.rep_reduct = &contin_reduction(reduct_effort, ignore_ops);
-        representation rep(tr, tt, ignore_ops, NULL, NULL, true, rep_params);
+        rep_params.linear_contin = true;
+        representation rep(tr, tt, ignore_ops, NULL, NULL, rep_params);
 
         TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
 
@@ -115,7 +116,7 @@ public:
         rep_params.perm_ratio = 1.0; // all permutation are generated,
                                      // that way we avoid sampling
 
-        representation rep(tr, tt, vertex_set(), nullptr, nullptr, false, rep_params);
+        representation rep(tr, tt, vertex_set(), nullptr, nullptr, rep_params);
 
         TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
 
@@ -141,7 +142,7 @@ public:
         rep_params.opt_reduct = &r.operator()(2);
         rep_params.rep_reduct = &r.operator()(2);
 
-        representation rep(tr, tt, vertex_set(), nullptr, nullptr, false, rep_params);
+        representation rep(tr, tt, vertex_set(), nullptr, nullptr, rep_params);
 
         TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
     }
@@ -158,7 +159,7 @@ public:
         rep_params.opt_reduct = &r.operator()(2);
         rep_params.rep_reduct = &r.operator()(2);
 
-        representation rep(tr, tt, vertex_set(), nullptr, nullptr, false, rep_params);
+        representation rep(tr, tt, vertex_set(), nullptr, nullptr, rep_params);
 
         TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
     }
@@ -175,7 +176,7 @@ public:
         rep_params.opt_reduct = &r.operator()(2);
         rep_params.rep_reduct = &r.operator()(2);
 
-        representation rep(tr, tt, vertex_set(), nullptr, nullptr, false, rep_params);
+        representation rep(tr, tt, vertex_set(), nullptr, nullptr, rep_params);
 
         TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
     }
@@ -192,7 +193,7 @@ public:
         rep_params.opt_reduct = &r.operator()(2);
         rep_params.rep_reduct = &r.operator()(0);
 
-        representation rep(tr, tt, vertex_set(), nullptr, nullptr, false, rep_params);
+        representation rep(tr, tt, vertex_set(), nullptr, nullptr, rep_params);
 
         TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
     }

--- a/tests/moses/representation/representationUTest.cxxtest
+++ b/tests/moses/representation/representationUTest.cxxtest
@@ -64,10 +64,10 @@ public:
         combo_tree tr = totree(tr_str);
         type_tree tt = infer_type_tree(tr);
         vertex_set ignore_ops{id::div, id::exp, id::log, id::sin};
-        representation rep(contin_reduction(reduct_effort, ignore_ops),
-                           contin_reduction(reduct_effort, ignore_ops),
-                           tr, tt, ignore_ops,
-                           NULL, NULL, false);
+        representation_parameters rep_params;
+        rep_params.opt_reduct = &contin_reduction(reduct_effort, ignore_ops);
+        rep_params.rep_reduct = &contin_reduction(reduct_effort, ignore_ops);
+        representation rep(tr, tt, ignore_ops, NULL, NULL, false, rep_params);
 
         TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
 
@@ -86,10 +86,10 @@ public:
         combo_tree tr = totree(tr_str);
         type_tree tt = infer_type_tree(tr);
         vertex_set ignore_ops{id::div, id::exp, id::log, id::sin};
-        representation rep(contin_reduction(reduct_effort, ignore_ops),
-                           contin_reduction(reduct_effort, ignore_ops),
-                           tr, tt, ignore_ops,
-                           NULL, NULL, true);
+        representation_parameters rep_params;
+        rep_params.opt_reduct = &contin_reduction(reduct_effort, ignore_ops);
+        rep_params.rep_reduct = &contin_reduction(reduct_effort, ignore_ops);
+        representation rep(tr, tt, ignore_ops, NULL, NULL, true, rep_params);
 
         TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
 
@@ -109,13 +109,13 @@ public:
 
         const vertex_set ignore_ops;
         logical_reduction r(ignore_ops);
-        const rule& r2 = r.operator()(2);
-        const rule& r3 = r.operator()(3);
+        representation_parameters rep_params;
+        rep_params.opt_reduct = &r.operator()(2);
+        rep_params.rep_reduct = &r.operator()(3);
+        rep_params.perm_ratio = 1.0; // all permutation are generated,
+                                     // that way we avoid sampling
 
-        representation rep(r2, r3, tr, tt, vertex_set(),
-                           nullptr, nullptr, false,
-                           1.0 /* all permutation are generated, that
-                                  way we avoid sampling */);
+        representation rep(tr, tt, vertex_set(), nullptr, nullptr, false, rep_params);
 
         TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
 
@@ -137,9 +137,11 @@ public:
 
         const vertex_set ignore_ops;
         logical_reduction r(ignore_ops);
-        const rule& r2 = r.operator()(2);
+        representation_parameters rep_params;
+        rep_params.opt_reduct = &r.operator()(2);
+        rep_params.rep_reduct = &r.operator()(2);
 
-        representation rep(r2, r2, tr, tt, vertex_set());
+        representation rep(tr, tt, vertex_set(), nullptr, nullptr, false, rep_params);
 
         TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
     }
@@ -152,9 +154,11 @@ public:
 
         const vertex_set ignore_ops;
         logical_reduction r(ignore_ops);
-        const rule& r2 = r.operator()(2);
+        representation_parameters rep_params;
+        rep_params.opt_reduct = &r.operator()(2);
+        rep_params.rep_reduct = &r.operator()(2);
 
-        representation rep(r2, r2, tr, tt, vertex_set());
+        representation rep(tr, tt, vertex_set(), nullptr, nullptr, false, rep_params);
 
         TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
     }
@@ -167,9 +171,11 @@ public:
 
         const vertex_set ignore_ops;
         logical_reduction r(ignore_ops);
-        const rule& r2 = r.operator()(2);
+        representation_parameters rep_params;
+        rep_params.opt_reduct = &r.operator()(2);
+        rep_params.rep_reduct = &r.operator()(2);
 
-        representation rep(r2, r2, tr, tt, vertex_set());
+        representation rep(tr, tt, vertex_set(), nullptr, nullptr, false, rep_params);
 
         TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
     }
@@ -182,10 +188,11 @@ public:
 
         const vertex_set ignore_ops;
         logical_reduction r(ignore_ops);
-        const rule& r2 = r.operator()(2);
-        const rule& r0 = r.operator()(0);
+        representation_parameters rep_params;
+        rep_params.opt_reduct = &r.operator()(2);
+        rep_params.rep_reduct = &r.operator()(0);
 
-        representation rep(r2, r0, tr, tt, vertex_set());
+        representation rep(tr, tt, vertex_set(), nullptr, nullptr, false, rep_params);
 
         TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
     }

--- a/tests/moses/representation/representationUTest.cxxtest
+++ b/tests/moses/representation/representationUTest.cxxtest
@@ -125,7 +125,7 @@ public:
 
         std::stringstream ss;
         rep.ostream_prototype(ss);
-        
+
         TS_ASSERT_EQUALS(ss.str(), expected_str);
     }
 

--- a/tests/moses/representation/representationUTest.cxxtest
+++ b/tests/moses/representation/representationUTest.cxxtest
@@ -39,164 +39,165 @@ using namespace std;
 
 class representationUTest : public CxxTest::TestSuite {
 private:
-    combo_tree totree(string str) {
-        stringstream ss(str);
-        combo_tree tr;
-        ss >> tr;
-        return tr;
-    }
+	combo_tree totree(string str) {
+		stringstream ss(str);
+		combo_tree tr;
+		ss >> tr;
+		return tr;
+	}
 
-    MT19937RandGen rng;
+	MT19937RandGen rng;
+
 public:
-    representationUTest() : rng(1)
-    {
-        logger().set_print_to_stdout_flag(true);
-        logger().set_level(Logger::DEBUG);
-    }
+	representationUTest() : rng(1)
+	{
+		logger().set_print_to_stdout_flag(true);
+		logger().set_level(Logger::DEBUG);
+	}
 
-    // these tests are just here to check that the representation
-    // building does not crash, for now at least
+	// these tests are just here to check that the representation
+	// building does not crash, for now at least
 
-    void test_contin_rep()
-    {
-        int reduct_effort = 2;
-        string tr_str = "+(*(+(*(+(*(+(*($1 1.75) 1.875) $1) 0.75) 0.75) 1.375) 0.75) -1.25)";
-        combo_tree tr = totree(tr_str);
-        type_tree tt = infer_type_tree(tr);
-        vertex_set ignore_ops{id::div, id::exp, id::log, id::sin};
-        representation_parameters rep_params;
-        rep_params.opt_reduct = &contin_reduction(reduct_effort, ignore_ops);
-        rep_params.rep_reduct = &contin_reduction(reduct_effort, ignore_ops);
-        rep_params.ignore_ops = ignore_ops;
-        representation rep(tr, tt, rep_params);
+	void test_contin_rep()
+	{
+		int reduct_effort = 2;
+		string tr_str = "+(*(+(*(+(*(+(*($1 1.75) 1.875) $1) 0.75) 0.75) 1.375) 0.75) -1.25)";
+		combo_tree tr = totree(tr_str);
+		type_tree tt = infer_type_tree(tr);
+		vertex_set ignore_ops{id::div, id::exp, id::log, id::sin};
+		representation_parameters rep_params;
+		rep_params.opt_reduct = &contin_reduction(reduct_effort, ignore_ops);
+		rep_params.rep_reduct = &contin_reduction(reduct_effort, ignore_ops);
+		rep_params.ignore_ops = ignore_ops;
+		representation rep(tr, tt, rep_params);
 
-        TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
+		TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
 
-        rep.ostream_prototype(std::cout << "Prototype = ") << std::endl;
+		rep.ostream_prototype(std::cout << "Prototype = ") << std::endl;
 
-        std::stringstream ss;
-        string expected_str("+(*(+(*(+(*(+(*(+(*($1 +([1.75] *([0] $1))) [1.875] *([0] $1)) $1 +([1] *([0] $1))) [0.75] *([0] $1)) +([0.75] *([0] $1))) [1.375] *([0] $1)) +([0.75] *([0] $1))) [0] *([0] $1)) [1]) [-1.25])");
-        rep.ostream_prototype(ss);
-        TS_ASSERT_EQUALS(ss.str(), expected_str);
-    }
+		std::stringstream ss;
+		string expected_str("+(*(+(*(+(*(+(*(+(*($1 +([1.75] *([0] $1))) [1.875] *([0] $1)) $1 +([1] *([0] $1))) [0.75] *([0] $1)) +([0.75] *([0] $1))) [1.375] *([0] $1)) +([0.75] *([0] $1))) [0] *([0] $1)) [1]) [-1.25])");
+		rep.ostream_prototype(ss);
+		TS_ASSERT_EQUALS(ss.str(), expected_str);
+	}
 
-    void test_linear_rep()
-    {
-        int reduct_effort = 2;
-        string tr_str = "+(*(+(*(+(*(+(*($1 1.75) 1.875) $1) 0.75) 0.75) 1.375) 0.75) -1.25)";
-        combo_tree tr = totree(tr_str);
-        type_tree tt = infer_type_tree(tr);
-        vertex_set ignore_ops{id::div, id::exp, id::log, id::sin};
-        representation_parameters rep_params;
-        rep_params.opt_reduct = &contin_reduction(reduct_effort, ignore_ops);
-        rep_params.rep_reduct = &contin_reduction(reduct_effort, ignore_ops);
-        rep_params.ignore_ops = ignore_ops;
-        rep_params.linear_contin = true;
-        representation rep(tr, tt, rep_params);
+	void test_linear_rep()
+	{
+		int reduct_effort = 2;
+		string tr_str = "+(*(+(*(+(*(+(*($1 1.75) 1.875) $1) 0.75) 0.75) 1.375) 0.75) -1.25)";
+		combo_tree tr = totree(tr_str);
+		type_tree tt = infer_type_tree(tr);
+		vertex_set ignore_ops{id::div, id::exp, id::log, id::sin};
+		representation_parameters rep_params;
+		rep_params.opt_reduct = &contin_reduction(reduct_effort, ignore_ops);
+		rep_params.rep_reduct = &contin_reduction(reduct_effort, ignore_ops);
+		rep_params.ignore_ops = ignore_ops;
+		rep_params.linear_contin = true;
+		representation rep(tr, tt, rep_params);
 
-        TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
+		TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
 
-        rep.ostream_prototype(std::cout << "Prototype = ") << std::endl;
+		rep.ostream_prototype(std::cout << "Prototype = ") << std::endl;
 
-        std::stringstream ss;
-        string expected_str("+(*(+(*(+(*(+(*(+(*($1 [1.75]) [1.875]) $1) [0.75]) [0.75]) [1.375]) [0.75]) [0] *([0] $1)) [1]) [-1.25])");
-        rep.ostream_prototype(ss);
-        TS_ASSERT_EQUALS(ss.str(), expected_str);
-    }
+		std::stringstream ss;
+		string expected_str("+(*(+(*(+(*(+(*(+(*($1 [1.75]) [1.875]) $1) [0.75]) [0.75]) [1.375]) [0.75]) [0] *([0] $1)) [1]) [-1.25])");
+		rep.ostream_prototype(ss);
+		TS_ASSERT_EQUALS(ss.str(), expected_str);
+	}
 
-    void test_boolean_rep1()
-    {
-        string tr_str = "and";
-        combo_tree tr = totree(tr_str);
-        type_tree tt = gen_signature(id::boolean_type, 3);
+	void test_boolean_rep1()
+	{
+		string tr_str = "and";
+		combo_tree tr = totree(tr_str);
+		type_tree tt = gen_signature(id::boolean_type, 3);
 
-        const vertex_set ignore_ops;
-        logical_reduction r(ignore_ops);
-        representation_parameters rep_params;
-        rep_params.opt_reduct = &r.operator()(2);
-        rep_params.rep_reduct = &r.operator()(3);
-        rep_params.perm_ratio = 1.0; // all permutation are generated,
-                                     // that way we avoid sampling
+		const vertex_set ignore_ops;
+		logical_reduction r(ignore_ops);
+		representation_parameters rep_params;
+		rep_params.opt_reduct = &r.operator()(2);
+		rep_params.rep_reduct = &r.operator()(3);
+		rep_params.perm_ratio = 1.0; // all permutation are generated,
+		// that way we avoid sampling
 
-        representation rep(tr, tt, rep_params);
+		representation rep(tr, tt, rep_params);
 
-        TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
+		TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
 
-        rep.ostream_prototype(std::cout << "Prototype = ") << std::endl;
+		rep.ostream_prototype(std::cout << "Prototype = ") << std::endl;
 
-        string expected_str("or(and([nil $1 !$1] [nil $2 !$2] [nil $3 !$3] [nil or !or]($1 $2) [nil or !or](!$2 $3) [nil or !or](!$1 $2) [nil or !or]($2 $3) [nil or !or](!$1 $3) [nil or !or]($1 $3) or([nil $1 !$1] [nil $2 !$2] [nil $3 !$3] [nil and !and](!$1 $3) [nil and !and]($2 $3) [nil and !and](!$1 $2) [nil and !and]($1 $2) [nil and !and](!$2 $3) [nil and !and]($1 $3))) [nil $1 !$1] [nil $2 !$2] [nil $3 !$3] [nil and !and](!$1 $3) [nil and !and]($1 $2) [nil and !and](!$1 $2) [nil and !and](!$2 $3) [nil and !and]($1 $3) [nil and !and]($2 $3) and([nil $1 !$1] [nil $2 !$2] [nil $3 !$3] [nil or !or]($1 $2) [nil or !or]($2 $3) [nil or !or]($1 $3) [nil or !or](!$1 $2) [nil or !or](!$1 $3) [nil or !or](!$2 $3)))");
+		string expected_str("or(and([nil $1 !$1] [nil $2 !$2] [nil $3 !$3] [nil or !or]($1 $2) [nil or !or](!$2 $3) [nil or !or](!$1 $2) [nil or !or]($2 $3) [nil or !or](!$1 $3) [nil or !or]($1 $3) or([nil $1 !$1] [nil $2 !$2] [nil $3 !$3] [nil and !and](!$1 $3) [nil and !and]($2 $3) [nil and !and](!$1 $2) [nil and !and]($1 $2) [nil and !and](!$2 $3) [nil and !and]($1 $3))) [nil $1 !$1] [nil $2 !$2] [nil $3 !$3] [nil and !and](!$1 $3) [nil and !and]($1 $2) [nil and !and](!$1 $2) [nil and !and](!$2 $3) [nil and !and]($1 $3) [nil and !and]($2 $3) and([nil $1 !$1] [nil $2 !$2] [nil $3 !$3] [nil or !or]($1 $2) [nil or !or]($2 $3) [nil or !or]($1 $3) [nil or !or](!$1 $2) [nil or !or](!$1 $3) [nil or !or](!$2 $3)))");
 
-        std::stringstream ss;
-        rep.ostream_prototype(ss);
+		std::stringstream ss;
+		rep.ostream_prototype(ss);
 
-        TS_ASSERT_EQUALS(ss.str(), expected_str);
-    }
+		TS_ASSERT_EQUALS(ss.str(), expected_str);
+	}
 
-    void test_boolean_rep2()
-    {
-        string tr_str = "or(and(or($1 $2) or($1 $3) or($2 $3)) and($1 $3))";
-        combo_tree tr = totree(tr_str);
-        type_tree tt = infer_type_tree(tr);
+	void test_boolean_rep2()
+	{
+		string tr_str = "or(and(or($1 $2) or($1 $3) or($2 $3)) and($1 $3))";
+		combo_tree tr = totree(tr_str);
+		type_tree tt = infer_type_tree(tr);
 
-        const vertex_set ignore_ops;
-        logical_reduction r(ignore_ops);
-        representation_parameters rep_params;
-        rep_params.opt_reduct = &r.operator()(2);
-        rep_params.rep_reduct = &r.operator()(2);
+		const vertex_set ignore_ops;
+		logical_reduction r(ignore_ops);
+		representation_parameters rep_params;
+		rep_params.opt_reduct = &r.operator()(2);
+		rep_params.rep_reduct = &r.operator()(2);
 
-        representation rep(tr, tt, rep_params);
+		representation rep(tr, tt, rep_params);
 
-        TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
-    }
+		TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
+	}
 
-    void test_boolean_rep3()
-    {
-        string tr_str = "or(and(!$1 !$2 !$3) and($1 $2) and($1 $3) and($2 $3))";
-        combo_tree tr = totree(tr_str);
-        type_tree tt = infer_type_tree(tr);
+	void test_boolean_rep3()
+	{
+		string tr_str = "or(and(!$1 !$2 !$3) and($1 $2) and($1 $3) and($2 $3))";
+		combo_tree tr = totree(tr_str);
+		type_tree tt = infer_type_tree(tr);
 
-        const vertex_set ignore_ops;
-        logical_reduction r(ignore_ops);
-        representation_parameters rep_params;
-        rep_params.opt_reduct = &r.operator()(2);
-        rep_params.rep_reduct = &r.operator()(2);
+		const vertex_set ignore_ops;
+		logical_reduction r(ignore_ops);
+		representation_parameters rep_params;
+		rep_params.opt_reduct = &r.operator()(2);
+		rep_params.rep_reduct = &r.operator()(2);
 
-        representation rep(tr, tt, rep_params);
+		representation rep(tr, tt, rep_params);
 
-        TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
-    }
+		TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
+	}
 
-    void test_boolean_rep4()
-    {
-        string tr_str = "or(and(or(and(or(!$1 $3) !$2) $3) or(and(!$2 $3) !$1) or($2 !$3)) and(or($1 $2) $3) and(or($1 $3) $2))";
-        combo_tree tr = totree(tr_str);
-        type_tree tt = infer_type_tree(tr);
+	void test_boolean_rep4()
+	{
+		string tr_str = "or(and(or(and(or(!$1 $3) !$2) $3) or(and(!$2 $3) !$1) or($2 !$3)) and(or($1 $2) $3) and(or($1 $3) $2))";
+		combo_tree tr = totree(tr_str);
+		type_tree tt = infer_type_tree(tr);
 
-        const vertex_set ignore_ops;
-        logical_reduction r(ignore_ops);
-        representation_parameters rep_params;
-        rep_params.opt_reduct = &r.operator()(2);
-        rep_params.rep_reduct = &r.operator()(2);
+		const vertex_set ignore_ops;
+		logical_reduction r(ignore_ops);
+		representation_parameters rep_params;
+		rep_params.opt_reduct = &r.operator()(2);
+		rep_params.rep_reduct = &r.operator()(2);
 
-        representation rep(tr, tt, rep_params);
+		representation rep(tr, tt, rep_params);
 
-        TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
-    }
+		TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
+	}
 
-    void test_boolean_rep5()
-    {
-        string tr_str = "or(and(!$2 !$3 or($3 !$2) or(!$1 $3)) and($3 $2) and($3 $1) and($1 $2 or($3 $1)))";
-        combo_tree tr = totree(tr_str);
-        type_tree tt = infer_type_tree(tr);
+	void test_boolean_rep5()
+	{
+		string tr_str = "or(and(!$2 !$3 or($3 !$2) or(!$1 $3)) and($3 $2) and($3 $1) and($1 $2 or($3 $1)))";
+		combo_tree tr = totree(tr_str);
+		type_tree tt = infer_type_tree(tr);
 
-        const vertex_set ignore_ops;
-        logical_reduction r(ignore_ops);
-        representation_parameters rep_params;
-        rep_params.opt_reduct = &r.operator()(2);
-        rep_params.rep_reduct = &r.operator()(0);
+		const vertex_set ignore_ops;
+		logical_reduction r(ignore_ops);
+		representation_parameters rep_params;
+		rep_params.opt_reduct = &r.operator()(2);
+		rep_params.rep_reduct = &r.operator()(0);
 
-        representation rep(tr, tt, rep_params);
+		representation rep(tr, tt, rep_params);
 
-        TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
-    }
+		TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
+	}
 };

--- a/tests/moses/representation/representationUTest.cxxtest
+++ b/tests/moses/representation/representationUTest.cxxtest
@@ -67,7 +67,7 @@ public:
         representation_parameters rep_params;
         rep_params.opt_reduct = &contin_reduction(reduct_effort, ignore_ops);
         rep_params.rep_reduct = &contin_reduction(reduct_effort, ignore_ops);
-        representation rep(tr, tt, ignore_ops, NULL, NULL, rep_params);
+        representation rep(tr, tt, ignore_ops, rep_params);
 
         TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
 
@@ -90,7 +90,7 @@ public:
         rep_params.opt_reduct = &contin_reduction(reduct_effort, ignore_ops);
         rep_params.rep_reduct = &contin_reduction(reduct_effort, ignore_ops);
         rep_params.linear_contin = true;
-        representation rep(tr, tt, ignore_ops, NULL, NULL, rep_params);
+        representation rep(tr, tt, ignore_ops, rep_params);
 
         TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
 
@@ -116,7 +116,7 @@ public:
         rep_params.perm_ratio = 1.0; // all permutation are generated,
                                      // that way we avoid sampling
 
-        representation rep(tr, tt, vertex_set(), nullptr, nullptr, rep_params);
+        representation rep(tr, tt, vertex_set(), rep_params);
 
         TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
 
@@ -142,7 +142,7 @@ public:
         rep_params.opt_reduct = &r.operator()(2);
         rep_params.rep_reduct = &r.operator()(2);
 
-        representation rep(tr, tt, vertex_set(), nullptr, nullptr, rep_params);
+        representation rep(tr, tt, vertex_set(), rep_params);
 
         TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
     }
@@ -159,7 +159,7 @@ public:
         rep_params.opt_reduct = &r.operator()(2);
         rep_params.rep_reduct = &r.operator()(2);
 
-        representation rep(tr, tt, vertex_set(), nullptr, nullptr, rep_params);
+        representation rep(tr, tt, vertex_set(), rep_params);
 
         TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
     }
@@ -176,7 +176,7 @@ public:
         rep_params.opt_reduct = &r.operator()(2);
         rep_params.rep_reduct = &r.operator()(2);
 
-        representation rep(tr, tt, vertex_set(), nullptr, nullptr, rep_params);
+        representation rep(tr, tt, vertex_set(), rep_params);
 
         TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
     }
@@ -193,7 +193,7 @@ public:
         rep_params.opt_reduct = &r.operator()(2);
         rep_params.rep_reduct = &r.operator()(0);
 
-        representation rep(tr, tt, vertex_set(), nullptr, nullptr, rep_params);
+        representation rep(tr, tt, vertex_set(), rep_params);
 
         TS_ASSERT_LESS_THAN(0, rep.fields().raw_size());
     }


### PR DESCRIPTION
Add a `--knob-probing` flag to completely disable (`0`), enable (`1`) or left unchanged `auto` knob probing.  Indeed in some cases, when for instance the exemplar is very large then knob probing can become a bottleneck.  Add to that the fact that it remains a heuristic that is not always desirable.

That PR contains also misc code improvements, formatting, comments, refactoring, etc.