### PR TITLE
remove obsolete std::unary_base

### DIFF
--- a/examples/ant-trails/ant_scoring.h
+++ b/examples/ant-trails/ant_scoring.h
@@ -76,7 +76,7 @@ static const char init_trail[ANT_Y][ANT_X+1] =
     "                                "
 };
 
-struct AntFitnessFunction : std::unary_function<combo_tree, score_t>
+struct AntFitnessFunction
 {
     typedef combo_tree::iterator pre_it;
     typedef combo_tree::sibling_iterator sib_it;

--- a/examples/c++-api/scoring_functions.h
+++ b/examples/c++-api/scoring_functions.h
@@ -61,7 +61,7 @@ unsigned int count_bitz(packed_t pack)
 }
 
 // Return, as the score, the total number of bits set in the instance.
-struct one_max : public unary_function<instance, int>
+struct one_max
 {
     int operator()(const instance& inst) const
     {
@@ -83,7 +83,7 @@ struct one_max : public unary_function<instance, int>
 
 // Return, as the score, the sum total settings of all discrete knob
 // settings in the instance.
-struct n_max : public unary_function<instance, int>
+struct n_max
 {
     n_max(const field_set& fs) : fields(fs) {}
     int operator()(const instance& inst) const
@@ -95,7 +95,7 @@ struct n_max : public unary_function<instance, int>
 
 // Return, as the score, the sum total of all continuous knob settings
 // in the instance.
-struct contin_max : public unary_function<instance, contin_t>
+struct contin_max
 {
     contin_max(const field_set& fs) : fields(fs) {}
     contin_t operator()(const instance& inst) const
@@ -115,7 +115,7 @@ struct contin_max : public unary_function<instance, contin_t>
 // and summed over, thus returning the "lp_1" distance between the instance,
 // and the random vector.
 //
-struct contin_uniform : public unary_function<instance, contin_t>
+struct contin_uniform
 {
     contin_uniform(const field_set& fs, contin_t minval, contin_t maxval)
         : fields(fs), target(fs.n_contin_fields())
@@ -143,7 +143,7 @@ struct contin_uniform : public unary_function<instance, contin_t>
 // Return, as the score, minus the sum of the squares of all
 // continuous knob settings in the instance.
 //
-struct sphere : public unary_function<instance, contin_t>
+struct sphere
 {
     sphere(const field_set& fs) : fields(fs) {}
     contin_t operator()(const instance& inst) const {
@@ -167,7 +167,7 @@ struct sphere : public unary_function<instance, contin_t>
 // character is an ASCII digit. This scoring function then goes over
 // all term knobs in the instance, pulls out these two digits, and
 // adds them together.  The sum of all of these is the returned score.
-struct termmax: public unary_function<instance, contin_t>
+struct termmax
 {
     termmax(const field_set& fs) : fields(fs) {}
     contin_t operator()(const instance& inst) const

--- a/opencog/asmoses/atomese/interpreter/condlink_interpreter.h
+++ b/opencog/asmoses/atomese/interpreter/condlink_interpreter.h
@@ -37,14 +37,11 @@ namespace opencog { namespace atomese {
  * which are the conditions, experssions, and defaults
  *
 */
-struct zip_cond :
-    public std::unary_function<const boost::tuple
-            <const ValuePtr &, const ValuePtr &, const ValuePtr &> &, void> {
+struct zip_cond
+{
     ValueSeq _result;
-
-    void operator()(
-        const boost::tuple<const ValuePtr &,
-                           const ValuePtr &, const ValuePtr &> &t);
+    void operator()(const boost::tuple<const ValuePtr &,
+                    const ValuePtr &, const ValuePtr &> &t);
 };
 
 /**
@@ -54,14 +51,11 @@ struct zip_cond :
  * which are the conditions, experssions, and defaults
  *
 */
-struct zip_cond2 :
-    public std::unary_function<const boost::tuple
-            <const ValuePtr &, const double &, const double &> &, void>{
+struct zip_cond2
+{
     std::vector<double> _result;
-
-    void operator()(
-            const boost::tuple<const ValuePtr &,
-                               const double &, const double &> &t);
+    void operator()(const boost::tuple<const ValuePtr &,
+                    const double &, const double &> &t);
 
 };
 
@@ -73,8 +67,8 @@ struct zip_cond2 :
  * @return  vector of valuePtr
  */
 ValueSeq condlink_exec_linkvalue(const LinkValuePtr &conds,
-								 const LinkValuePtr &exps,
-								 const LinkValuePtr &default_exp);
+                                 const LinkValuePtr &exps,
+                                 const LinkValuePtr &default_exp);
 
 /**
  * this function works when input columns are floatValues
@@ -84,7 +78,7 @@ ValueSeq condlink_exec_linkvalue(const LinkValuePtr &conds,
  * @return  vector of double
  */
 std::vector<double> condlink_exec_floatvalue(const LinkValuePtr &conds,
-											 const FloatValuePtr &exps,
-											 const FloatValuePtr &default_exp);
+                                             const FloatValuePtr &exps,
+                                             const FloatValuePtr &default_exp);
 }}
 #endif //ASMOSES_CONDLINK_INTERPRETER_H

--- a/opencog/asmoses/atomese/interpreter/logical_interpreter.h
+++ b/opencog/asmoses/atomese/interpreter/logical_interpreter.h
@@ -36,12 +36,9 @@ namespace opencog { namespace atomese {
  * this struct is expected to be used in boost::zip_iterator to perform
  * logical_and on LinkValues containing TRUE_LINK and FALSE_LINK.
  */
-struct zip_and :
-		public std::unary_function<const boost::tuple
-				<const ValuePtr&, const ValuePtr&>&, void>
+struct zip_and
 {
 	ValueSeq _result;
-
 	void operator()(const boost::tuple<const ValuePtr&, const ValuePtr&>& t);
 };
 
@@ -50,24 +47,18 @@ struct zip_and :
  * this struct is expected to be used in boost::zip_iterator to perform
  * logical_or on LinkValues containing TRUE_LINK and FALSE_LINK.
  */
-struct zip_or :
-		public std::unary_function<const boost::tuple
-				<const ValuePtr&, const ValuePtr&>&, void>
+struct zip_or
 {
 	ValueSeq _result;
-
 	void operator()(const boost::tuple<const ValuePtr&, const ValuePtr&>& t);
 };
 
 /**
  * Performs greater_than comparison of two doubles.
  */
-struct zip_greater_than :
-		public std::unary_function<const boost::tuple
-				<const double&, const double&>&, void>
+struct zip_greater_than
 {
 	ValueSeq _result;
-
 	void operator()(const boost::tuple<const double&, const double&>& t);
 };
 

--- a/opencog/asmoses/combo/type_checker/type_tree.h
+++ b/opencog/asmoses/combo/type_checker/type_tree.h
@@ -120,7 +120,8 @@ type_tree get_type_tree(const vertex& v);
 // returns true iff ty1 inherits ty2 and ty2 inherits ty1
 bool equal_type_tree(const type_tree& ty1, const type_tree& ty2);
 
-struct equal_to_type_tree : std::unary_function<const type_tree&, bool> {
+struct equal_to_type_tree
+{
 private:
     const type_tree& _tt;
 public:
@@ -172,7 +173,8 @@ public:
  */
 bool inherit_type_tree(const type_tree& ty1, const type_tree& ty2);
 
-struct inherit_from_type_tree : std::unary_function<const type_tree&, bool> {
+struct inherit_from_type_tree
+{
 private:
     const type_tree& _tt;
 public:

--- a/opencog/asmoses/feature-selection/main/feature-selection.h
+++ b/opencog/asmoses/feature-selection/main/feature-selection.h
@@ -157,7 +157,7 @@ struct iscorer_cache : public iscorer_base
 
 
 template<typename FeatureSet>
-struct fs_scorer : public std::unary_function<FeatureSet, double>
+struct fs_scorer
 {
     fs_scorer(const CompressedTable& ctable,
               const feature_selection_parameters& fs_params)

--- a/opencog/asmoses/feature-selection/scorers/fs_scorer_base.h
+++ b/opencog/asmoses/feature-selection/scorers/fs_scorer_base.h
@@ -31,7 +31,7 @@ namespace opencog {
 using namespace combo;
 
 template<typename FeatureSet>
-struct fs_scorer_base : public std::unary_function<FeatureSet, double>
+struct fs_scorer_base
 {
     // ctor
     fs_scorer_base(const CompressedTable& ctable, double confi)

--- a/opencog/asmoses/feature-selection/scorers/mutual_info.h
+++ b/opencog/asmoses/feature-selection/scorers/mutual_info.h
@@ -43,9 +43,8 @@ using namespace combo;
  * The actual work is done in the combo table code.
  */
 template<typename FeatureSet>
-struct MutualInformation : public std::unary_function<FeatureSet, double>
+struct MutualInformation
 {
-
     MutualInformation(const CompressedTable& ctable)
         : _ctable(ctable) {}
 
@@ -78,7 +77,7 @@ protected:
  * is a bug in our MI code???)
  */
 template<typename FeatureSet>
-struct MICScorer : public std::unary_function<FeatureSet, double>
+struct MICScorer
 {
     MICScorer(const ITable& it, const OTable& ot,
               double confi = 100)

--- a/opencog/asmoses/feature-selection/scorers/mutual_info.h
+++ b/opencog/asmoses/feature-selection/scorers/mutual_info.h
@@ -48,6 +48,8 @@ struct MutualInformation
     MutualInformation(const CompressedTable& ctable)
         : _ctable(ctable) {}
 
+    typedef FeatureSet argument_type;
+    typedef double result_type;
     double operator()(const FeatureSet& features) const
     {
         return mutualInformation(_ctable, features);
@@ -79,6 +81,8 @@ protected:
 template<typename FeatureSet>
 struct MICScorer
 {
+    typedef FeatureSet argument_type;
+    typedef double result_type;
     MICScorer(const ITable& it, const OTable& ot,
               double confi = 100)
         : _it(it), _ot(ot), _confi(confi) {}

--- a/opencog/asmoses/moses/moses/types.h
+++ b/opencog/asmoses/moses/moses/types.h
@@ -431,7 +431,6 @@ public:
  * (as these are usually very bad candidates).
  */
 struct sct_score_greater
-	: public std::binary_function<scored_combo_tree, scored_combo_tree, bool>
 {
 	bool operator()(const scored_combo_tree&,
 	                const scored_combo_tree&) const;
@@ -443,20 +442,17 @@ struct sct_score_greater
  * equality requires two  lexicographic compares :-(
  */
 struct sct_tree_greater
-	: public std::binary_function<scored_combo_tree, scored_combo_tree, bool>
 {
 	bool operator()(const scored_combo_tree&,
 	                const scored_combo_tree&) const;
 };
 
 struct scored_combo_tree_hash
-	: public std::unary_function<scored_combo_tree, size_t>
 {
 	size_t operator()(const scored_combo_tree&) const;
 };
 
 struct scored_combo_tree_equal
-	: public std::binary_function<scored_combo_tree, scored_combo_tree, bool>
 {
 	bool operator()(const scored_combo_tree&,
 	                const scored_combo_tree&) const;
@@ -464,20 +460,17 @@ struct scored_combo_tree_equal
 
 /// atomese
 struct sa_score_greater
-	: public std::binary_function<scored_atomese, scored_atomese, bool>
 {
 	bool operator()(const scored_atomese&,
 	                const scored_atomese&) const;
 };
 
 struct scored_atomese_hash
-	: public std::unary_function<scored_atomese, size_t>
 {
 	size_t operator()(const scored_atomese&) const;
 };
 
 struct scored_atomese_equal
-	: public std::binary_function<scored_atomese, scored_atomese, bool>
 {
 	bool operator()(const scored_atomese&,
 	                const scored_atomese&) const;

--- a/opencog/asmoses/moses/representation/instance.h
+++ b/opencog/asmoses/moses/representation/instance.h
@@ -45,4 +45,20 @@ typedef std::vector<packed_t> instance;
 } // ~namespace moses
 } // ~namespace opencog
 
+// This is to enable std::unordered_map and similar
+namespace std
+{
+	template<>
+	struct hash<opencog::moses::instance>
+	{
+		size_t operator()(const opencog::moses::instance& nstc) const
+		{
+			size_t hsh = 0;
+			for (unsigned long int bs: nstc)
+				hsh = (hsh << 1) ^ std::hash<unsigned long int>{}(bs);
+			return hsh;
+		}
+	};
+}
+
 #endif

--- a/opencog/asmoses/moses/representation/instance_scorer.h
+++ b/opencog/asmoses/moses/representation/instance_scorer.h
@@ -39,7 +39,7 @@ namespace moses
 
 struct iscorer_base
 {
-	typedef const instance& argument_type;
+	typedef instance argument_type;
 	typedef composite_score result_type;
 	virtual composite_score operator()(const instance &) const = 0;
 	virtual ~iscorer_base() {}

--- a/opencog/asmoses/moses/representation/instance_scorer.h
+++ b/opencog/asmoses/moses/representation/instance_scorer.h
@@ -37,12 +37,12 @@ namespace opencog
 namespace moses
 {
 
-struct iscorer_base : public std::unary_function<instance, composite_score>
+struct iscorer_base
 {
+	typedef const instance& argument_type;
+	typedef composite_score result_type;
 	virtual composite_score operator()(const instance &) const = 0;
-
-	virtual ~iscorer_base()
-	{}
+	virtual ~iscorer_base() {}
 };
 
 /**

--- a/opencog/asmoses/moses/scoring/behave_cscore.h
+++ b/opencog/asmoses/moses/scoring/behave_cscore.h
@@ -122,17 +122,19 @@ private:
 
 	// Below follows some assorted infrastructure to allow composite
 	// scoress for trees to be cached.
-	struct wrapper : public std::unary_function<combo_tree, composite_score>
+	struct wrapper
 	{
+		typedef combo_tree argument_type;
+		typedef composite_score result_type;
 		composite_score operator()(const combo_tree &) const;
-
 		behave_cscore *self;
 	};
 
-	struct atomese_wrapper : public std::unary_function<Handle, composite_score>
+	struct atomese_wrapper
 	{
+		typedef Handle argument_type;
+		typedef composite_score result_type;
 		composite_score operator()(const Handle &) const;
-
 		behave_cscore *self;
 	};
 


### PR DESCRIPTION
This was marked deprecated in c++11 and removed in c++17 Source no longer builds with this.