### PR TITLE
Add hash functions for std::unodered_map

### DIFF
--- a/opencog/asmoses/combo/combo/vertex.h
+++ b/opencog/asmoses/combo/combo/vertex.h
@@ -427,14 +427,14 @@ inline bool operator!=(const vertex& v1, const vertex& v2)
 }
 #endif
 
-inline size_t hash_value(const message& m)
+inline size_t hash_value(const message& m) noexcept
 {
     /// WARNING: let the boost namespace as it permits to not generate
     /// infinit recursive calls of hash_value(const vertex& v)
     return boost::hash_value(m.getContent());
 }
 
-inline size_t hash_value(const vertex& v)
+inline size_t hash_value(const vertex& v) noexcept
 {
     using boost::hash_combine;
 
@@ -833,9 +833,22 @@ namespace std
     template<>
     struct hash<opencog::combo::vertex>
     {
-        size_t operator()(opencog::combo::vertex v) const
+        size_t operator()(const opencog::combo::vertex& v) const noexcept
         {
             return opencog::combo::hash_value(v);
+        }
+    };
+
+    template<>
+    struct hash<opencog::tree<opencog::combo::vertex>>
+    {
+        size_t operator()(const opencog::tree<opencog::combo::vertex>& tre) const noexcept
+        {
+				size_t hsh = 0;
+				for (const opencog::combo::vertex& v: tre)
+					hsh ^= std::hash<opencog::combo::vertex>{}(v)
+						+ 0x9e3779b9 + (hsh << 6) + (hsh >> 2);
+            return hsh;
         }
     };
 }

--- a/opencog/asmoses/feature-selection/main/feature-selection.h
+++ b/opencog/asmoses/feature-selection/main/feature-selection.h
@@ -231,11 +231,12 @@ namespace std
 	template<>
 	struct hash<opencog::feature_set>
 	{
-		size_t operator()(const opencog::feature_set& fs) const
+		size_t operator()(const opencog::feature_set& fs) const noexcept
 		{
 			size_t hsh = 0;
 			for (int ii: fs)
-				hsh = (hsh << 1) ^ std::hash<opencog::arity_t>{}(ii);
+				hsh ^= std::hash<opencog::arity_t>{}(ii)
+					+ 0x9e3779b9 + (hsh << 6) + (hsh >> 2);
 			return hsh;
 		}
 	};

--- a/opencog/asmoses/feature-selection/main/feature-selection.h
+++ b/opencog/asmoses/feature-selection/main/feature-selection.h
@@ -225,4 +225,20 @@ void feature_selection(const Table& table,
 
 } // ~namespace opencog
 
+// This allows std::unordered_map to be used.
+namespace std
+{
+	template<>
+	struct hash<opencog::feature_set>
+	{
+		size_t operator()(const opencog::feature_set& fs) const
+		{
+			size_t hsh = 0;
+			for (int ii: fs)
+				hsh = (hsh << 1) ^ std::hash<opencog::arity_t>{}(ii);
+			return hsh;
+		}
+	};
+}
+
 #endif // _OPENCOG_FEATURE-SELECTION_H

--- a/opencog/asmoses/moses/representation/instance.h
+++ b/opencog/asmoses/moses/representation/instance.h
@@ -51,11 +51,12 @@ namespace std
 	template<>
 	struct hash<opencog::moses::instance>
 	{
-		size_t operator()(const opencog::moses::instance& nstc) const
+		size_t operator()(const opencog::moses::instance& nstc) const noexcept
 		{
 			size_t hsh = 0;
 			for (unsigned long int bs: nstc)
-				hsh = (hsh << 1) ^ std::hash<unsigned long int>{}(bs);
+				hsh ^= std::hash<unsigned long int>{}(bs)
+					+ 0x9e3779b9 + (hsh << 6) + (hsh >> 2);
 			return hsh;
 		}
 	};


### PR DESCRIPTION
Custom hash functions are needed, to allow std::unordered_set to compile.
Add the missing functions.