### PR TITLE
Fix representationUTest

### DIFF
--- a/tests/moses/representation/CMakeLists.txt
+++ b/tests/moses/representation/CMakeLists.txt
@@ -1,12 +1,12 @@
 
 # This test fails in Ubntu 22.04 and I don't have time to debug it,
 # so I am commenting it out.
-#ADD_CXXTEST(representationUTest)
-#TARGET_LINK_LIBRARIES(representationUTest
-#        moses
-#        ascombo
-#        ${COGUTIL_LIBRARY}
-#        )
+ADD_CXXTEST(representationUTest)
+TARGET_LINK_LIBRARIES(representationUTest
+        moses
+        ascombo
+        ${COGUTIL_LIBRARY}
+        )
 
 ADD_CXXTEST(AtomeseRepresentationUTest)
 TARGET_LINK_LIBRARIES(AtomeseRepresentationUTest

--- a/tests/moses/representation/representationUTest.cxxtest
+++ b/tests/moses/representation/representationUTest.cxxtest
@@ -125,7 +125,7 @@ public:
 
 		rep.ostream_prototype(std::cout << "Prototype = ") << std::endl;
 
-		string expected_str("or(and([nil $1 !$1] [nil $2 !$2] [nil $3 !$3] [nil or !or]($1 $2) [nil or !or](!$2 $3) [nil or !or](!$1 $2) [nil or !or]($2 $3) [nil or !or](!$1 $3) [nil or !or]($1 $3) or([nil $1 !$1] [nil $2 !$2] [nil $3 !$3] [nil and !and](!$1 $3) [nil and !and]($2 $3) [nil and !and](!$1 $2) [nil and !and]($1 $2) [nil and !and](!$2 $3) [nil and !and]($1 $3))) [nil $1 !$1] [nil $2 !$2] [nil $3 !$3] [nil and !and](!$1 $3) [nil and !and]($1 $2) [nil and !and](!$1 $2) [nil and !and](!$2 $3) [nil and !and]($1 $3) [nil and !and]($2 $3) and([nil $1 !$1] [nil $2 !$2] [nil $3 !$3] [nil or !or]($1 $2) [nil or !or]($2 $3) [nil or !or]($1 $3) [nil or !or](!$1 $2) [nil or !or](!$1 $3) [nil or !or](!$2 $3)))");
+		string expected_str("or(and([nil $1 !$1] [nil $2 !$2] [nil $3 !$3] [nil or !or](!$2 $3) [nil or !or](!$1 $2) [nil or !or](!$1 $3) [nil or !or]($1 $2) [nil or !or]($1 $3) [nil or !or]($2 $3) or([nil $1 !$1] [nil $2 !$2] [nil $3 !$3] [nil and !and](!$1 $2) [nil and !and](!$1 $3) [nil and !and]($2 $3) [nil and !and]($1 $3) [nil and !and]($1 $2) [nil and !and](!$2 $3))) [nil $1 !$1] [nil $2 !$2] [nil $3 !$3] [nil and !and]($1 $3) [nil and !and](!$1 $3) [nil and !and]($1 $2) [nil and !and](!$1 $2) [nil and !and](!$2 $3) [nil and !and]($2 $3) and([nil $1 !$1] [nil $2 !$2] [nil $3 !$3] [nil or !or](!$1 $3) [nil or !or]($1 $3) [nil or !or](!$1 $2) [nil or !or]($2 $3) [nil or !or]($1 $2) [nil or !or](!$2 $3)))");
 
 		std::stringstream ss;
 		rep.ostream_prototype(ss);


### PR DESCRIPTION
Sometime after 2020, the new gcc's changed order of execution, which changed how permutations were being created. The complete tre is still generated, its just in a diffrent order. So adjust unit test for that.